### PR TITLE
Add optional detailed candidate plotting

### DIFF
--- a/effelsberg/config.py
+++ b/effelsberg/config.py
@@ -26,6 +26,9 @@ DET_PROB: float = 0.5
 DM_min: int = 0
 DM_max: int = 129
 
+# Plotting --------------------------------------------------------------------
+PLOT_DETAILED: bool = False
+
 # Paths -----------------------------------------------------------------------
 DATA_DIR = Path("./Data")
 RESULTS_DIR = Path("./Results/ObjectDetection")


### PR DESCRIPTION
## Summary
- add `PLOT_DETAILED` option in `config.py`
- implement `save_detection_plot` to replicate the labelled plots from the
  original script
- call the new plotting function in `run_pipeline` when enabled

## Testing
- `python -m py_compile effelsberg/config.py effelsberg/image_utils.py effelsberg/pipeline.py`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_684df4b8514c8322ade4ca72511dc6c1