### PR TITLE
Add configurable FRB targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ For complete FAST observation data:
 
 1. Refer to `d-center-main.py` and `d-resnet-main.py`
 2. Modify the `data path` and `save path`
-3. Run the file
+3. Set `FRB_TARGETS` in `effelsberg/config.py` to match the FRB names in your FITS files
+4. Run the file
 
 **Note:** The current search program automatically adapts to FAST and GBT observation data. For other telescopes, modify the `load_fits_file` function and related data reading functions.
 

--- a/effelsberg/config.py
+++ b/effelsberg/config.py
@@ -31,3 +31,8 @@ DATA_DIR = Path("./Data")
 RESULTS_DIR = Path("./Results/ObjectDetection")
 MODEL_NAME = "resnet50"
 MODEL_PATH = Path(f"cent_{MODEL_NAME}.pth")
+
+# Default FRB targets --------------------------------------------------------
+# List of substrings used to select FITS files corresponding to specific
+# observations. Update this list to search for other FRBs.
+FRB_TARGETS = ["B0355+54"]

--- a/effelsberg/pipeline.py
+++ b/effelsberg/pipeline.py
@@ -30,7 +30,7 @@ def run_pipeline() -> None:
 
     summary: dict[str, dict] = {}
 
-    for frb in ["B0355+54"]:
+    for frb in config.FRB_TARGETS:
         file_list = sorted([f for f in config.DATA_DIR.glob("*.fits") if frb in f.name])
         if not file_list:
             continue


### PR DESCRIPTION
## Summary
- add `FRB_TARGETS` list to `effelsberg/config.py`
- use `config.FRB_TARGETS` in `run_pipeline`
- document `FRB_TARGETS` in README

## Testing
- `python -m py_compile effelsberg/config.py effelsberg/pipeline.py Effelsberg.py effelsberg/__main__.py`

------
https://chatgpt.com/codex/tasks/task_e_684df4bba5b4832294f152322f47e30b