### PR TITLE
Decouple pipeline summary functions

### DIFF
--- a/DRAFTS/filterbank_io.py
+++ b/DRAFTS/filterbank_io.py
@@ -9,6 +9,7 @@ from typing import Tuple
 import numpy as np
 
 from . import config
+from .summary_utils import _update_summary_with_file_debug
 
 
 def _read_int(f) -> int:
@@ -498,10 +499,8 @@ def get_obparams_fil(file_name: str) -> None:
 def _save_file_debug_info_fil(file_name: str, debug_info: dict) -> None:
     """Save debug information for a filterbank file to summary.json immediately."""
     try:
-        # Import aquí para evitar import circular
-        from .pipeline import _update_summary_with_file_debug
         from pathlib import Path
-        
+
         # Determinar el directorio de guardado
         results_dir = getattr(config, 'RESULTS_DIR', Path('./Results/ObjectDetection'))
         model_dir = results_dir / config.MODEL_NAME

--- a/DRAFTS/io.py
+++ b/DRAFTS/io.py
@@ -8,6 +8,7 @@ import numpy as np
 from astropy.io import fits
 
 from . import config
+from .summary_utils import _update_summary_with_file_debug
 
 
 def load_fits_file(file_name: str) -> np.ndarray:
@@ -428,8 +429,6 @@ def get_obparams(file_name: str) -> None:
 def _save_file_debug_info_fits(file_name: str, debug_info: dict) -> None:
     """Save debug information for a FITS file to summary.json immediately."""
     try:
-        # Import aquí para evitar import circular
-        from .pipeline import _update_summary_with_file_debug
         from pathlib import Path
         import os
         

--- a/DRAFTS/summary_utils.py
+++ b/DRAFTS/summary_utils.py
@@ -1,0 +1,101 @@
+import json
+import logging
+import time
+from pathlib import Path
+
+from . import config
+
+logger = logging.getLogger(__name__)
+
+
+def _write_summary(summary: dict, save_path: Path) -> None:
+    """Write global summary information to ``summary.json``."""
+
+    summary_path = save_path / "summary.json"
+    with summary_path.open("w") as f_json:
+        json.dump(summary, f_json, indent=2)
+    logger.info("Resumen global escrito en %s", summary_path)
+
+
+def _load_or_create_summary(save_path: Path) -> dict:
+    """Load existing summary.json or create a new one."""
+    summary_path = save_path / "summary.json"
+
+    if summary_path.exists():
+        try:
+            with summary_path.open("r") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, FileNotFoundError):
+            logger.warning(f"Error leyendo {summary_path}, creando nuevo summary")
+
+    # Crear nuevo summary con estructura inicial
+    return {
+        "pipeline_info": {
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "model": config.MODEL_NAME,
+            "dm_range": f"{config.DM_min}-{config.DM_max}",
+            "slice_duration_ms": config.SLICE_DURATION_MS,
+            "debug_enabled": config.DEBUG_FREQUENCY_ORDER,
+        },
+        "files_processed": {},
+        "global_stats": {
+            "total_files": 0,
+            "total_candidates": 0,
+            "total_bursts": 0,
+            "total_processing_time": 0.0,
+        },
+    }
+
+
+def _update_summary_with_file_debug(
+    save_path: Path, filename: str, debug_info: dict
+) -> None:
+    """Update summary.json immediately with file debug information."""
+
+    summary = _load_or_create_summary(save_path)
+
+    if filename not in summary["files_processed"]:
+        summary["files_processed"][filename] = {}
+
+    summary["files_processed"][filename]["debug_info"] = debug_info
+    summary["files_processed"][filename]["status"] = "debug_completed"
+    summary["files_processed"][filename]["debug_timestamp"] = time.strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+
+    summary_path = save_path / "summary.json"
+    with summary_path.open("w") as f:
+        json.dump(summary, f, indent=2)
+
+    if config.DEBUG_FREQUENCY_ORDER:
+        logger.info(f"Debug info guardada para {filename} en {summary_path}")
+
+
+def _update_summary_with_results(
+    save_path: Path, filename: str, results_info: dict
+) -> None:
+    """Update summary.json with processing results for a file."""
+
+    summary = _load_or_create_summary(save_path)
+
+    if filename not in summary["files_processed"]:
+        summary["files_processed"][filename] = {}
+
+    summary["files_processed"][filename].update(results_info)
+    summary["files_processed"][filename]["status"] = "processing_completed"
+    summary["files_processed"][filename]["results_timestamp"] = time.strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+
+    summary["global_stats"]["total_files"] = len(summary["files_processed"])
+    summary["global_stats"]["total_candidates"] += results_info.get("n_candidates", 0)
+    summary["global_stats"]["total_bursts"] += results_info.get("n_bursts", 0)
+    summary["global_stats"]["total_processing_time"] += results_info.get(
+        "processing_time", 0.0
+    )
+
+    summary_path = save_path / "summary.json"
+    with summary_path.open("w") as f:
+        json.dump(summary, f, indent=2)
+
+    logger.info(f"Resultados guardados para {filename} en {summary_path}")


### PR DESCRIPTION
## Summary
- move summary helpers to new `summary_utils` module
- import summary utilities in `pipeline`, `io` and `filterbank_io`
- remove circular dependency between `io` and `pipeline`