### PR TITLE
Add flag to force generation of debug plots

### DIFF
--- a/drafts/pipeline.py
+++ b/drafts/pipeline.py
@@ -303,7 +303,8 @@ def _process_block(
                 composite_dir=composite_dir,
                 detections_dir=detections_dir,
                 patches_dir=patches_dir,
-                chunk_idx=chunk_idx 
+                chunk_idx=chunk_idx,
+                force_plots=config.FORCE_PLOTS,
             )
 
             cand_counter += cands
@@ -594,7 +595,8 @@ def _process_file(
             chunk_idx=0,  # chunk_idx=0 para archivos no chunked
             composite_dir=composite_dir,  # pasar directorio composite
             detections_dir=detections_dir,  # pasar directorio detections
-            patches_dir=patches_dir  # pasar directorio patches
+            patches_dir=patches_dir,  # pasar directorio patches
+            force_plots=config.FORCE_PLOTS,
         )
         cand_counter += cands
         n_bursts += bursts

--- a/drafts/user_config.py
+++ b/drafts/user_config.py
@@ -63,6 +63,9 @@ USE_MULTI_BAND: bool = False                # True = usar análisis multi-banda,
 DEBUG_FREQUENCY_ORDER: bool = False        # True = mostrar información detallada de frecuencias y archivos
                                            # False = modo silencioso (recomendado para procesamiento en lote)
 
+# Forzar generación de plots incluso sin candidatos (modo debug)
+FORCE_PLOTS: bool = False                  # True = siempre generar plots para inspección
+
 # Configuración de logging
 LOG_LEVEL: str = "INFO"                     # Nivel de logging: DEBUG, INFO, WARNING, ERROR
 LOG_COLORS: bool = True                     # Usar colores en la consola

--- a/drafts/visualization/visualization_unified.py
+++ b/drafts/visualization/visualization_unified.py
@@ -451,7 +451,8 @@ def save_all_plots(
     detections_dir,
     out_img_path,
     absolute_start_time=None,
-    chunk_idx=None  # PARÁMETRO PARA CHUNK
+    chunk_idx=None,  # PARÁMETRO PARA CHUNK
+    force_plots: bool = False,
 ):
     """Guarda todos los plots con tiempo absoluto para continuidad temporal.
     
@@ -487,15 +488,16 @@ def save_all_plots(
             chunk_idx=chunk_idx,  # 🆕 PASAR CHUNK_ID
         )
     
-    # Patch plot - crear carpeta solo si hay patch para guardar
-    if first_patch is not None and patch_path is not None:
+    # Patch plot - crear carpeta solo si hay patch o si se fuerza en modo debug
+    if patch_path is not None and (first_patch is not None or force_plots):
         patch_path.parent.mkdir(parents=True, exist_ok=True)
+        patch_data = first_patch if first_patch is not None else np.zeros((10, 10))
         save_patch_plot(
-            first_patch,
+            patch_data,
             patch_path,
             freq_down,
             time_reso_ds,
-            first_start,
+            first_start if first_start is not None else 0.0,
             off_regions=off_regions,
             thresh_snr=thresh_snr,
             band_idx=band_idx,


### PR DESCRIPTION
## Summary
- allow forcing plot creation via `FORCE_PLOTS` config flag
- propagate flag through pipeline to plot even without detections
- support debug patch placeholders when no candidate exists

## Testing
- `pytest -q` *(fails: Unescaped '\\' in a string (at line 250, column 10))*

------
https://chatgpt.com/codex/tasks/task_e_6894411708e48322b22e307279800db2