### PR TITLE
Feat/edge cases

### DIFF
--- a/drafts/analysis/snr_utils.py
+++ b/drafts/analysis/snr_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import numpy as np
 from typing import List, Tuple, Optional
 
-from .. import config
+# Nota: este módulo no requiere configuración global del pipeline
 
 
 def compute_snr_profile(
@@ -116,104 +116,7 @@ def find_snr_peak(snr: np.ndarray, time_axis: Optional[np.ndarray] = None) -> Tu
     return peak_snr, peak_time, peak_idx
 
 
-def create_snr_regions_around_peak(
-    peak_idx: int, 
-    profile_length: int, 
-    region_width: int = 50
-) -> List[Tuple[int, int]]:
-    """
-    Create off-pulse regions around a detected peak.
-    
-    Parameters
-    ----------
-    peak_idx : int
-        Index of the detected peak
-    profile_length : int
-        Total length of the profile
-    region_width : int
-        Width of each off-pulse region
-        
-    Returns
-    -------
-    List[Tuple[int, int]]
-        List of (start, end) indices for off-pulse regions
-    """
-    regions = []
-    
-    # Left region
-    left_end = peak_idx - region_width
-    left_start = left_end - region_width
-    if left_start >= 0:
-        regions.append((left_start, left_end))
-    
-    # Right region  
-    right_start = peak_idx + region_width
-    right_end = right_start + region_width
-    if right_end < profile_length:
-        regions.append((right_start, right_end))
-        
-    # Far left region if space allows
-    if left_start >= region_width:
-        far_left_end = left_start - region_width // 2
-        far_left_start = far_left_end - region_width
-        if far_left_start >= 0:
-            regions.append((far_left_start, far_left_end))
-    
-    return regions
-
-
-def create_centered_off_regions(
-    profile_length: int,
-    center_exclusion_width: int = 100,
-    region_width: int = 50
-) -> List[Tuple[int, int]]:
-    """
-    Crea regiones off-pulse optimizadas para pulsos centralizados.
-    
-    Parameters
-    ----------
-    profile_length : int
-        Longitud total del perfil temporal
-    center_exclusion_width : int
-        Ancho de la región central a excluir (donde está el pulso)
-    region_width : int
-        Ancho de cada región off-pulse
-    
-    Returns
-    -------
-    List[Tuple[int, int]]
-        Lista de regiones off-pulse optimizadas
-    """
-    center = profile_length // 2
-    half_exclusion = center_exclusion_width // 2
-    
-    regions = []
-    
-    # Región izquierda cercana
-    left_near_end = center - half_exclusion
-    left_near_start = left_near_end - region_width
-    if left_near_start >= 0:
-        regions.append((left_near_start, left_near_end))
-    
-    # Región derecha cercana
-    right_near_start = center + half_exclusion
-    right_near_end = right_near_start + region_width
-    if right_near_end < profile_length:
-        regions.append((right_near_start, right_near_end))
-    
-    # Región izquierda lejana
-    left_far_end = left_near_start - region_width // 2
-    left_far_start = left_far_end - region_width
-    if left_far_start >= 0:
-        regions.append((left_far_start, left_far_end))
-    
-    # Región derecha lejana
-    right_far_start = right_near_end + region_width // 2
-    right_far_end = right_far_start + region_width
-    if right_far_end < profile_length:
-        regions.append((right_far_start, right_far_end))
-    
-    return regions
+## Nota: se eliminaron utilidades de regiones off-pulse no utilizadas por el pipeline
 
 
 def inject_synthetic_frb(

--- a/drafts/detection_engine.py
+++ b/drafts/detection_engine.py
@@ -304,6 +304,27 @@ def process_slice(
         start_idx = slice_len * j
         end_idx = slice_len * (j + 1)
 
+    # Log: muestras exactas usadas en el slice (dominio decimado)
+    try:
+        real_samples = end_idx - start_idx
+        if global_logger:
+            chunk_info = f" (chunk {chunk_idx:03d})" if chunk_idx is not None else ""
+            global_logger.logger.info(
+                f"{Colors.PROCESSING} Slice {j:03d}{chunk_info}: {real_samples} muestras reales "
+                f"(decimado) [{start_idx}→{end_idx}){Colors.ENDC}"
+            )
+        else:
+            logger.info(
+                f"Slice {j:03d}: {end_idx - start_idx} muestras reales (decimado) "
+                f"[{start_idx}→{end_idx})"
+            )
+    except Exception:
+        # Fallback silencioso si falla el logger global/Colors
+        logger.info(
+            f"Slice {j:03d}: {end_idx - start_idx} muestras reales (decimado) "
+            f"[{start_idx}→{end_idx})"
+        )
+
     slice_cube = dm_time[:, :, start_idx:end_idx]
     waterfall_block = block[start_idx:end_idx]
     if slice_cube.size == 0 or waterfall_block.size == 0:

--- a/drafts/output/summary_manager.py
+++ b/drafts/output/summary_manager.py
@@ -9,16 +9,6 @@ from .. import config
 
 logger = logging.getLogger(__name__)
 
-
-def _write_summary(summary: dict, save_path: Path) -> None:
-    """Write global summary information to ``summary.json``."""
-
-    summary_path = save_path / "summary.json"
-    with summary_path.open("w") as f_json:
-        json.dump(summary, f_json, indent=2)
-    logger.info("Resumen global escrito en %s", summary_path)
-
-
 def _write_summary_with_timestamp(summary: dict, save_path: Path, preserve_history: bool = True) -> None:
     """
     Write summary with timestamp and optionally preserve historical summaries.
@@ -220,64 +210,3 @@ def _update_summary_with_results(
         json.dump(summary, f, indent=2)
 
     logger.info(f"Resultados guardados para {filename} en {summary_path}") 
-
-
-def get_execution_history(save_path: Path, limit: int = 10) -> list:
-    """
-    Get recent execution history from master summary.
-    
-    Parameters
-    ----------
-    save_path : Path
-        Directory containing the master summary
-    limit : int
-        Maximum number of recent executions to return
-        
-    Returns
-    -------
-    list
-        List of recent execution records
-    """
-    master_path = save_path / "summary_master.json"
-    if not master_path.exists():
-        return []
-    
-    try:
-        with master_path.open("r") as f:
-            master_summary = json.load(f)
-        
-        history = master_summary.get("execution_history", [])
-        return history[-limit:] if limit > 0 else history
-        
-    except Exception as e:
-        logger.error(f"Error leyendo historial de ejecuciones: {e}")
-        return []
-
-
-def get_cumulative_stats(save_path: Path) -> dict:
-    """
-    Get cumulative statistics from all executions.
-    
-    Parameters
-    ----------
-    save_path : Path
-        Directory containing the master summary
-        
-    Returns
-    -------
-    dict
-        Cumulative statistics
-    """
-    master_path = save_path / "summary_master.json"
-    if not master_path.exists():
-        return {}
-    
-    try:
-        with master_path.open("r") as f:
-            master_summary = json.load(f)
-        
-        return master_summary.get("cumulative_stats", {})
-        
-    except Exception as e:
-        logger.error(f"Error leyendo estadísticas acumuladas: {e}")
-        return {} 

--- a/drafts/pipeline.py
+++ b/drafts/pipeline.py
@@ -333,14 +333,7 @@ def _process_block(
             n_no_bursts += no_bursts
             prob_max = max(prob_max, max_prob)
             
-            # Mensaje de resumen del slice si tiene candidatos
-            if cands > 0:
-                try:
-                    from .logging.logging_config import get_global_logger
-                    global_logger = get_global_logger()
-                    global_logger.slice_completed(j, cands, bursts, no_bursts)
-                except ImportError:
-                    pass
+            # Evitar log duplicado: el resumen de slice se registra dentro de detection_engine.process_slice
 
             # LIMPIEZA DE MEMORIA DESPUÉS DE CADA SLICE
             if j % 10 == 0:  # Cada 10 slices
@@ -624,14 +617,7 @@ def _process_file(
         n_no_bursts += no_bursts
         prob_max = max(prob_max, max_prob)
         
-        # Mensaje de resumen del slice si tiene candidatos
-        if cands > 0:
-            try:
-                from .logging.logging_config import get_global_logger
-                global_logger = get_global_logger()
-                global_logger.slice_completed(j, cands, bursts, no_bursts)
-            except ImportError:
-                pass
+        # Evitar log duplicado: el resumen de slice se registra dentro de detection_engine.process_slice
     runtime = time.time() - t_start
     logger.info(
         "\u25b6 %s: %d candidatos, max prob %.2f, \u23f1 %.1f s",

--- a/drafts/pipeline.py
+++ b/drafts/pipeline.py
@@ -115,16 +115,17 @@ def _process_block(
     """Procesa un bloque de datos y retorna estadísticas del bloque."""
     
     # Configurar parámetros temporales para este bloque
-    original_file_leng = config.FILE_LENG # Guardar longitud original del archivo
-    config.FILE_LENG = metadata["actual_chunk_size"] # Actualizar longitud del archivo al tamaño del bloque actual
+    original_file_leng = config.FILE_LENG
+    # Tamaño válido (sin solape) después del downsampling
+    config.FILE_LENG = metadata["actual_chunk_size"]
     
     # CALCULAR TIEMPO ABSOLUTO DESDE INICIO DEL ARCHIVO
     # Tiempo de inicio del chunk en segundos desde el inicio del archivo
     # CORRECCIÓN: Usar tiempo efectivo después del downsampling
     # Importante: el offset absoluto del chunk se calcula en base al tiempo por muestra original (sin downsampling)
     # El factor de downsampling temporal sólo aplica a duraciones dentro de datos ya decimados.
-    chunk_start_time_sec = metadata["start_sample"] * config.TIME_RESO  # Tiempo absoluto desde inicio del archivo
-    chunk_duration_sec = metadata["actual_chunk_size"] * config.TIME_RESO  # Duración real del chunk
+    chunk_start_time_sec = metadata["start_sample"] * config.TIME_RESO
+    chunk_duration_sec = metadata["actual_chunk_size"] * config.TIME_RESO
     
     # =============================================================================
     # LOGGING INFORMATIVO DETALLADO DEL CHUNK
@@ -144,7 +145,8 @@ def _process_block(
     try:
         # Aplicar downsampling al bloque
         from .preprocessing.data_downsampler import downsample_data # Importar la función de downsampling
-        block = downsample_data(block) # Aplica downsampling según la configuración 
+        # Aplica downsampling manteniendo la estructura (incluye solape crudo)
+        block = downsample_data(block)
         
         # Calcular parámetros para este bloque
         freq_down = np.mean(
@@ -152,8 +154,14 @@ def _process_block(
             axis=1,
         ) # Promedio de frecuencias después del downsampling
         
-        height = config.DM_max - config.DM_min + 1 # Altura del cubo DM
-        width_total = config.FILE_LENG // config.DOWN_TIME_RATE # Ancho total del cubo DM-time
+        height = config.DM_max - config.DM_min + 1
+
+        # Ancho válido (sin solape) tras decimación
+        width_total = config.FILE_LENG // config.DOWN_TIME_RATE
+
+        # Calcular solapamiento equivalente en muestras decimadas
+        overlap_left_ds = int((metadata.get("overlap_left", 0)) // config.DOWN_TIME_RATE)
+        overlap_right_ds = int((metadata.get("overlap_right", 0)) // config.DOWN_TIME_RATE)
         
         # Calcular slice_len dinámicamente
         from .preprocessing.slice_len_calculator import update_slice_len_dynamic # Importar la función de actualización de slice_len
@@ -163,7 +171,18 @@ def _process_block(
         logger.info(f"Chunk {chunk_idx:03d}: {metadata['actual_chunk_size']} muestras → {time_slice} slices")
         
         # Generar DM-time cube
-        dm_time = d_dm_time_g(block, height=height, width=width_total) # dedispersion del bloque
+        # Construir cubo DM-time sobre el bloque completo con solapes
+        dm_time_full = d_dm_time_g(block, height=height, width=block.shape[0])
+
+        # Extraer ventana válida (sin bordes inválidos) usando los solapes decimados
+        # La parte válida empieza en overlap_left_ds y termina en block.shape[0] - overlap_right_ds
+        valid_start_ds = max(0, overlap_left_ds)
+        valid_end_ds = block.shape[0] - max(0, overlap_right_ds)
+        if valid_end_ds <= valid_start_ds:
+            valid_start_ds, valid_end_ds = 0, block.shape[0]
+
+        dm_time = dm_time_full[:, :, valid_start_ds:valid_end_ds]
+        block = block[valid_start_ds:valid_end_ds]
         
         # Configurar bandas
         band_configs = get_band_configs() # Configuración de bandas (fullband, lowband, highband)
@@ -445,8 +464,19 @@ def _process_file_chunked(
     actual_chunk_count = 0 # Contador de chunks procesados
     
     try:
-        # Procesar cada bloque (UNA SOLA PASADA)
-        for block, metadata in stream_fil(str(fits_path), chunk_samples): # Procesar cada bloque
+        # Calcular Δt_max para determinar solapamiento en bruto
+        freq_ds = np.mean(
+            config.FREQ.reshape(config.FREQ_RESO // config.DOWN_FREQ_RATE, config.DOWN_FREQ_RATE),
+            axis=1,
+        )
+        nu_min = float(freq_ds.min())
+        nu_max = float(freq_ds.max())
+        # Usamos constante para frecuencias en MHz: Δt_sec = 4.1488e3 * DM * (ν_min^-2 − ν_max^-2)
+        dt_max_sec = 4.1488e3 * config.DM_max * (nu_min**-2 - nu_max**-2)
+        overlap_raw = int(np.ceil(dt_max_sec / config.TIME_RESO))
+
+        # Procesar cada bloque con solapamiento
+        for block, metadata in stream_fil(str(fits_path), chunk_samples, overlap_samples=overlap_raw):
             actual_chunk_count += 1 # Incrementar el contador de chunks procesados
             logger.info(f"Procesando chunk {metadata['chunk_idx']:03d} " # Log del chunk actual
                        f"({metadata['start_sample']:,} - {metadata['end_sample']:,})") # Log del rango de muestras del chunk

--- a/drafts/user_config.py
+++ b/drafts/user_config.py
@@ -18,7 +18,7 @@ FRB_TARGETS = [
 # =============================================================================
 
 # Duración de cada slice temporal (milisegundos)
-SLICE_DURATION_MS: float = 500.0
+SLICE_DURATION_MS: float = 500.0 # Testear con 1034
 
 # =============================================================================
 # CONFIGURACIÓN DE DOWNSAMPLING
@@ -34,8 +34,8 @@ DOWN_TIME_RATE: int = 14                     # Factor de reducción en tiempo (1
 # =============================================================================
 
 # Rango de Dispersion Measure para búsqueda
-DM_min: int = 500                             # DM mínimo en pc cm⁻³
-DM_max: int = 600                          # DM máximo en pc cm⁻³
+DM_min: int = 0                             # DM mínimo en pc cm⁻³
+DM_max: int = 1024                          # DM máximo en pc cm⁻³
 
 # =============================================================================
 # UMBRALES DE DETECCIÓN
@@ -88,3 +88,13 @@ OVERHEAD_FACTOR: float = 1.3                # Factor de overhead por copias/buff
 # Tolerancias y límites de slicing
 TIME_TOL_MS: float = 0.1                    # Tolerancia temporal al ajustar la duración objetivo del slice
 MAX_SLICE_COUNT: int = 5000                 # Límite superior de slices por chunk
+
+# =============================================================================
+# FLAGS AVANZADOS PARA MITIGAR ARTEFACTOS Y MEJORAR ESTABILIDAD
+# =============================================================================
+
+# Pre-whitening por canal antes de construir el cubo DM–tiempo (z-score por canal)
+PREWHITEN_BEFORE_DM: bool = True
+
+# Sombrear visualmente la cola inválida en los waterfalls cuando no hay solapamiento
+SHADE_INVALID_TAIL: bool = True

--- a/drafts/user_config.py
+++ b/drafts/user_config.py
@@ -34,8 +34,8 @@ DOWN_TIME_RATE: int = 14                     # Factor de reducción en tiempo (1
 # =============================================================================
 
 # Rango de Dispersion Measure para búsqueda
-DM_min: int = 0                             # DM mínimo en pc cm⁻³
-DM_max: int = 1024                          # DM máximo en pc cm⁻³
+DM_min: int = 500                             # DM mínimo en pc cm⁻³
+DM_max: int = 600                          # DM máximo en pc cm⁻³
 
 # =============================================================================
 # UMBRALES DE DETECCIÓN

--- a/drafts/visualization/visualization_unified.py
+++ b/drafts/visualization/visualization_unified.py
@@ -38,84 +38,48 @@ def _calculate_dynamic_dm_range(
     fallback_dm_max: int = None,
     confidence_scores: Iterable | None = None
 ) -> Tuple[float, float]:
-    """
-    Calcula el rango DM dinámico basado en los candidatos detectados.
-    
-    Parameters
-    ----------
-    top_boxes : Iterable | None
-        Bounding boxes de los candidatos detectados
-    slice_len : int
-        Longitud del slice temporal
-    fallback_dm_min : int, optional
-        DM mínimo de fallback si no se puede calcular dinámicamente
-    fallback_dm_max : int, optional
-        DM máximo de fallback si no se puede calcular dinámicamente
-    confidence_scores : Iterable | None, optional
-        Puntuaciones de confianza para cada candidato
-        
-    Returns
-    -------
-    Tuple[float, float]
-        (dm_plot_min, dm_plot_max) para el rango DM dinámico
-    """
-    
-    # Si no hay candidatos o DM dinámico deshabilitado, usar rango completo
-    if (not getattr(config, 'DM_DYNAMIC_RANGE_ENABLE', True) or 
-        top_boxes is None or 
-        len(top_boxes) == 0):
-        
+    """Delegado unificado: usa visualization_ranges para rango DM dinámico."""
+    if (not getattr(config, 'DM_DYNAMIC_RANGE_ENABLE', True)
+        or top_boxes is None
+        or len(top_boxes) == 0):
         dm_min = fallback_dm_min if fallback_dm_min is not None else config.DM_min
         dm_max = fallback_dm_max if fallback_dm_max is not None else config.DM_max
         return float(dm_min), float(dm_max)
-    
-    # Extraer DMs de los candidatos
-    dm_candidates = []
-    for i, box in enumerate(top_boxes):
+
+    dm_candidates: List[float] = []
+    for box in top_boxes:
         x1, y1, x2, y2 = map(int, box)
         center_x, center_y = (x1 + x2) / 2, (y1 + y2) / 2
         dm_val, _, _ = extract_candidate_dm(center_x, center_y, slice_len)
         dm_candidates.append(dm_val)
-    
     if not dm_candidates:
         dm_min = fallback_dm_min if fallback_dm_min is not None else config.DM_min
         dm_max = fallback_dm_max if fallback_dm_max is not None else config.DM_max
         return float(dm_min), float(dm_max)
-    
-    # Usar el candidato más fuerte (mejor confianza) como referencia
+
     if confidence_scores is not None and len(confidence_scores) > 0:
-        best_idx = np.argmax(confidence_scores)
-        dm_optimal = dm_candidates[best_idx]
-        confidence = confidence_scores[best_idx]
+        best_idx = int(np.argmax(confidence_scores))
+        dm_optimal = float(dm_candidates[best_idx])
+        confidence = float(confidence_scores[best_idx])
     else:
-        # Si no hay confianza, usar el DM mediano
-        dm_optimal = np.median(dm_candidates)
-        confidence = 0.8  # Valor por defecto
-    
-    # Calcular rango dinámico
+        dm_optimal = float(np.median(dm_candidates))
+        confidence = 0.8
+
     try:
-        # Obtener parámetros de configuración
-        range_factor = getattr(config, 'DM_RANGE_FACTOR', 0.2)
-        min_width = getattr(config, 'DM_RANGE_MIN_WIDTH', 50.0)
-        max_width = getattr(config, 'DM_RANGE_MAX_WIDTH', 200.0)
-        
-        dm_plot_min, dm_plot_max = get_dynamic_dm_range_for_candidate(
+        return get_dynamic_dm_range_for_candidate(
             dm_optimal=dm_optimal,
             config_module=config,
             visualization_type=getattr(config, 'DM_RANGE_DEFAULT_VISUALIZATION', 'detailed'),
             confidence=confidence,
-            range_factor=range_factor,
-            min_range_width=min_width,
-            max_range_width=max_width
+            range_factor=getattr(config, 'DM_RANGE_FACTOR', 0.2),
+            min_range_width=getattr(config, 'DM_RANGE_MIN_WIDTH', 50.0),
+            max_range_width=getattr(config, 'DM_RANGE_MAX_WIDTH', 200.0),
         )
     except Exception as e:
-        # En caso de error, usar rango completo
         print(f"[WARNING] Error calculando rango DM dinámico: {e}")
         dm_min = fallback_dm_min if fallback_dm_min is not None else config.DM_min
         dm_max = fallback_dm_max if fallback_dm_max is not None else config.DM_max
         return float(dm_min), float(dm_max)
-    
-    return dm_plot_min, dm_plot_max
 
 
 def preprocess_img(img: np.ndarray) -> np.ndarray:
@@ -259,8 +223,7 @@ def save_detection_plot(
     # Time axis labels
     n_time_ticks = 6
     time_positions = np.linspace(0, 512, n_time_ticks)
-    
-    # 🕐 USAR TIEMPO ABSOLUTO SI SE PROPORCIONA
+
     if absolute_start_time is not None:
         time_start_slice = absolute_start_time
     else:
@@ -648,10 +611,7 @@ def save_plot(
     absolute_start_time: Optional[float] = None,  # 🕐 NUEVO PARÁMETRO PARA TIEMPO ABSOLUTO
     slice_samples: Optional[int] = None,  # 🕐 NUEVO: muestras reales en el slice
 ) -> None:
-    """Wrapper around :func:`save_detection_plot` with dynamic slice length."""
-
-    prev_len = config.SLICE_LEN
-    config.SLICE_LEN = slice_len
+    """Wrapper fino sin mutar estado global; pasa slice_len explícito."""
     
     # Agregar información de rango de frecuencias al nombre de la banda
     band_name_with_freq = get_band_name_with_freq_range(band_idx, band_name)
@@ -673,8 +633,7 @@ def save_plot(
         absolute_start_time=absolute_start_time, 
         slice_samples=slice_samples,
     )
-    
-    config.SLICE_LEN = prev_len
+    # No modificar config.SLICE_LEN global
 
 
 def save_patch_plot(


### PR DESCRIPTION
feat(dedispersion): add chunk overlap + exposure-normalized DM–time; fix CPU fallback; optional pre-whitening and invalid-tail shading

- Stream .fil with real chunk overlap computed from Δt_max (DM_max, ν range)
- Carry overlap metadata and crop the valid window post-downsampling
- Normalize DM–time per (DM,t) by number of contributing channels (GPU kernel and CPU path)
- Fix CPU fallback dedispersion bounds (correct per-channel slicing with delays)
- Optional per-channel pre-whitening (z-score) before DM cube
- Visualization: shade invalid tail in waterfalls (estimated by Δt_max)
- Add flags: PREWHITEN_BEFORE_DM, SHADE_INVALID_TAIL

Why: removes triangular/oblique edge artifacts in DM–time and stabilizes SNR near block boundaries

Affects: drafts/input/data_loader.py, drafts/pipeline.py, drafts/preprocessing/dedispersion.py, drafts/visualization/visualization_unified.py, drafts/user_config.py