### PR TITLE
refactor: translate pipeline comments and update helpers

### DIFF
--- a/src/analysis/snr_utils.py
+++ b/src/analysis/snr_utils.py
@@ -12,31 +12,29 @@ import numpy as np
                                                                  
 
 
-# This function computes SNR profile.
 def compute_snr_profile(
     waterfall: np.ndarray,
     off_regions: Optional[List[Tuple[int, int]]] = None
 ) -> Tuple[np.ndarray, float, np.ndarray]:
-    """
-    Calcula un único perfil SNR unificado (estilo PRESTO) desde un waterfall 2D.
+    """Compute a unified PRESTO-style SNR profile from a 2D waterfall.
 
-    Flujo:
-    - Integración en frecuencia → serie temporal
-    - Detrend/normalización por bloques (RMS≈1) con corrección 1.148
-    - Matched filtering con boxcars normalizados por √width
-    - Devuelve el perfil SNR máximo por muestra y sigma≈1.0
+    Pipeline:
+    - Integrate over frequency to obtain a time series
+    - Detrend/normalize in blocks (RMS≈1) with the 1.148 correction
+    - Apply matched filtering with boxcars normalized by ``√width``
+    - Return the per-sample maximum SNR and effective sigma≈1.0
 
-    Nota: el parámetro off_regions se mantiene por compatibilidad pero no se usa
-    en este esquema, ya que la normalización por bloques ya estabiliza la RMS.
+    The ``off_regions`` parameter is kept for compatibility but is unused because
+    block normalization already stabilizes the RMS.
 
     Returns
     -------
     snr : np.ndarray
-        Perfil SNR 1D (máximo sobre anchos) con shape (n_time,)
+        1D SNR profile (maximum over widths) with shape ``(n_time,)``
     sigma : float
-        Desviación estándar efectiva del ruido (≈1.0 tras normalización)
+        Effective noise standard deviation (≈1.0 after normalization)
     best_width : np.ndarray
-        Ancho de boxcar (en muestras) que maximiza el SNR en cada muestra
+        Boxcar width (in samples) that maximizes the SNR at each sample
     """
     if waterfall is None or waterfall.size == 0:
         raise ValueError("waterfall is None or empty in compute_snr_profile")
@@ -71,7 +69,6 @@ def compute_snr_profile(
                             posinf=np.max(snr_max[np.isfinite(snr_max)]) if np.isfinite(snr_max).any() else 0.0)
     return snr_max, 1.0, best_width
 
-# This function estimates sigma iqr.
 def estimate_sigma_iqr(data: np.ndarray) -> float:
     """
     Estimate noise standard deviation using the Interquartile Range method.
@@ -94,7 +91,6 @@ def estimate_sigma_iqr(data: np.ndarray) -> float:
     return iqr / 1.349
 
 
-# This function finds SNR peak.
 def find_snr_peak(snr: np.ndarray, time_axis: Optional[np.ndarray] = None) -> Tuple[float, float, int]:
     """
     Find the peak SNR value and its location.
@@ -122,7 +118,6 @@ def find_snr_peak(snr: np.ndarray, time_axis: Optional[np.ndarray] = None) -> Tu
     return peak_snr, peak_time, peak_idx
 
 
-# This function detrends and normalizes a time series.
 def _detrend_normalize_timeseries(timeseries: np.ndarray) -> np.ndarray:
     """Approximate PRESTO-style detrend and normalize to RMS≈1.
 
@@ -271,7 +266,6 @@ def compute_presto_matched_snr(
                                                                                      
 
 
-# This function injects synthetic FRB.
 def inject_synthetic_frb(
     waterfall: np.ndarray,
     peak_time_idx: int,
@@ -321,7 +315,6 @@ def inject_synthetic_frb(
     return waterfall_with_pulse
 
 
-# This function computes detection significance.
 def compute_detection_significance(
     snr_peak: float, 
     n_samples: int, 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -184,7 +184,6 @@ SHADE_INVALID_TAIL: bool = True
                                       
                                                                                
 
-# This function gets band configs.
 def get_band_configs():
     """Retorna la configuración de bandas según USE_MULTI_BAND"""
     return [
@@ -198,7 +197,6 @@ def get_band_configs():
                                                        
                                                                                
 
-# This function validates configuration.
 def validate_configuration():
     """
     Valida la configuración del sistema y genera mensajes de error informativos.
@@ -301,7 +299,6 @@ def validate_configuration():
     return True
 
 
-# This function checks model files.
 def check_model_files():
     """
     Verifica que los archivos de modelo existan y sean accesibles.

--- a/src/config/user_config.py
+++ b/src/config/user_config.py
@@ -1,99 +1,99 @@
 from pathlib import Path
 
 # =============================================================================
-# CONFIGURACIÓN DE DATOS Y ARCHIVOS
+# DATA AND FILE CONFIGURATION
 # =============================================================================
 
-# Directorios de entrada y salida
-DATA_DIR = Path("./Data/raw")                        # Directorio con archivos de entrada (.fits, .fil)
-RESULTS_DIR = Path("./fusion-tests")                      # Directorio para guardar resultados
+# Input and output directories
+DATA_DIR = Path("./Data/raw")                        # Directory with input files (.fits, .fil)
+RESULTS_DIR = Path("./fusion-tests")                      # Directory where results are stored
 
-# Lista de archivos a procesar
+# List of files to process
 FRB_TARGETS = [
    "2017-04-03-12_56_05_230_0002_t2.3_t17.395"
 ]
 
 # =============================================================================
-# CONFIGURACIÓN DE ANÁLISIS TEMPORAL
+# TEMPORAL ANALYSIS CONFIGURATION
 # =============================================================================
 
-# Duración de cada slice temporal (milisegundos)
+# Duration of each temporal slice (milliseconds)
 SLICE_DURATION_MS: float = 300.0
 
 # =============================================================================
-# CONFIGURACIÓN DE DOWNSAMPLING
+# DOWNSAMPLING CONFIGURATION
 # =============================================================================
 
-# Factores de reducción para optimizar el procesamiento
-DOWN_FREQ_RATE: int = 1                      # Factor de reducción en frecuencia (1 = sin reducción)
-DOWN_TIME_RATE: int = 8                     # Factor de reducción en tiempo (1 = sin reducción)
+# Reduction factors to optimize processing
+DOWN_FREQ_RATE: int = 1                      # Frequency reduction factor (1 = no reduction)
+DOWN_TIME_RATE: int = 8                     # Time reduction factor (1 = no reduction)
 
 
 # =============================================================================
-# CONFIGURACIÓN DE DISPERSIÓN (DM)
+# DISPERSION MEASURE CONFIGURATION (DM)
 # =============================================================================
 
-# Rango de Dispersion Measure para búsqueda
-DM_min: int = 0                             # DM mínimo en pc cm⁻³
-DM_max: int = 1024                          # DM máximo en pc cm⁻³
+# Dispersion Measure search range
+DM_min: int = 0                             # Minimum DM in pc cm⁻³
+DM_max: int = 1024                          # Maximum DM in pc cm⁻³
 
 # =============================================================================
-# UMBRALES DE DETECCIÓN
+# DETECTION THRESHOLDS
 # =============================================================================
 
-# Probabilidades mínimas para detección y clasificación
-DET_PROB: float = 0.3                       # Probabilidad mínima para considerar una detección válida
-CLASS_PROB: float = 0.5                     # Probabilidad mínima para clasificar como burst
+# Minimum probabilities for detection and classification
+DET_PROB: float = 0.3                       # Minimum probability to consider a detection valid
+CLASS_PROB: float = 0.5                     # Minimum probability to classify as burst
 
-# Umbral de SNR para resaltar en visualizaciones
-SNR_THRESH: float = 4.0                     # Umbral de SNR para resaltar en visualizaciones
-
-# =============================================================================
-# CONFIGURACIÓN DE ANÁLISIS MULTI-BANDA
-# =============================================================================
-
-# Análisis multi-banda (Full/Low/High)
-USE_MULTI_BAND: bool = False                # True = usar análisis multi-banda, False = solo banda completa
+# SNR threshold for highlighting in visualizations
+SNR_THRESH: float = 4.0                     # SNR threshold used in plots
 
 # =============================================================================
-
-# CONFIGURACIÓN DEL PIPELINE DE ALTA FRECUENCIA
+# MULTI-BAND ANALYSIS CONFIGURATION
 # =============================================================================
 
-# Controla si el pipeline de alta frecuencia se activa automáticamente
-# según la frecuencia central del archivo (por defecto, ≥ 8000 MHz)
+# Multi-band analysis (Full/Low/High)
+USE_MULTI_BAND: bool = False                # True = enable multi-band analysis, False = only full band
+
+# =============================================================================
+
+# HIGH-FREQUENCY PIPELINE CONFIGURATION
+# =============================================================================
+
+# Controls whether the high-frequency pipeline is triggered automatically
+# based on the file's central frequency (default ≥ 8000 MHz)
 AUTO_HIGH_FREQ_PIPELINE: bool = False
 
-# Umbral de frecuencia central (en MHz) para considerar "alta frecuencia"
+# Central frequency threshold (MHz) to consider "high frequency"
 HIGH_FREQ_THRESHOLD_MHZ: float = 8000.0
 
 # =============================================================================
-# CONFIGURACIÓN DE POLARIZACIÓN (ENTRADA PSRFITS)
+# POLARIZATION CONFIGURATION (PSRFITS INPUT)
 # =============================================================================
 
-# Modo de polarización para PSRFITS con POL_TYPE=IQUV y npol>=4
-# Opciones: "intensity" (I), "linear" (sqrt(Q^2+U^2)), "circular" (abs(V)),
-#           "pol0", "pol1", "pol2", "pol3" para seleccionar un índice específico
+# Polarization mode for PSRFITS with POL_TYPE=IQUV and npol>=4
+# Options: "intensity" (I), "linear" (sqrt(Q^2+U^2)), "circular" (abs(V)),
+#          "pol0", "pol1", "pol2", "pol3" to select a specific index
 POLARIZATION_MODE: str = "intensity"
 
-# Índice por defecto si no hay IQUV (e.g., AABB, dos pols)
+# Default index when IQUV is not available (e.g., AABB, two pols)
 POLARIZATION_INDEX: int = 0
 
 # =============================================================================
-# CONFIGURACIÓN DE LOGGING Y DEBUG
+# LOGGING AND DEBUG CONFIGURATION
 # =============================================================================
 
-# Debug de frecuencias y archivos
-DEBUG_FREQUENCY_ORDER: bool = True        # True = mostrar información detallada de frecuencias y archivos
-                                           # False = modo silencioso (recomendado para procesamiento en lote)
+# Frequency and file debugging
+DEBUG_FREQUENCY_ORDER: bool = True        # True = show detailed frequency and file information
+                                           # False = quiet mode (recommended for batch processing)
 
-# Forzar generación de plots incluso sin candidatos (modo debug)
-FORCE_PLOTS: bool = False                  # True = siempre generar plots para inspección
+# Force plot generation even when no candidates (debug mode)
+FORCE_PLOTS: bool = False                  # True = always generate plots for inspection
 
 # =============================================================================
-# CONFIGURACIÓN DE FILTRADO DE CANDIDATOS
+# CANDIDATE FILTERING CONFIGURATION
 # =============================================================================
 
-# Solo guardar y mostrar candidatos clasificados como BURST
-SAVE_ONLY_BURST: bool = True             # True = solo guardar candidatos BURST, False = guardar todos los candidatos
+# Only save and display candidates classified as BURST
+SAVE_ONLY_BURST: bool = True             # True = keep only BURST candidates, False = keep all candidates
 

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,14 +1,6 @@
 # This module aggregates the core pipeline interfaces.
 
-"""Módulo core del pipeline de detección de FRBs.
-
-Este módulo contiene la lógica principal del pipeline:
-
-- pipeline: Orquestación principal del flujo de procesamiento
-- detection_engine: Motor de detección, clasificación y coordinación de visualizaciones
-- pipeline_parameters: Cálculos centralizados de parámetros del pipeline
-- data_flow_manager: Gestión de chunks, slices y flujo de datos
-"""
+"""Core building blocks used to assemble the FRB detection pipeline."""
 
 from .detection_engine import process_slice_with_multiple_bands
 from .pipeline_parameters import (
@@ -17,8 +9,6 @@ from .pipeline_parameters import (
     calculate_width_total,
     calculate_slice_parameters,
     calculate_time_slice,
-    calculate_slice_duration,
-    get_pipeline_parameters,
     calculate_overlap_decimated,
     calculate_absolute_slice_time,
 )
@@ -42,8 +32,6 @@ __all__ = [
     'calculate_width_total',
     'calculate_slice_parameters',
     'calculate_time_slice',
-    'calculate_slice_duration',
-    'get_pipeline_parameters',
     'calculate_overlap_decimated',
     'calculate_absolute_slice_time',
     

--- a/src/core/data_flow_manager.py
+++ b/src/core/data_flow_manager.py
@@ -1,6 +1,6 @@
 # This module manages chunk-level data flow operations.
 
-"""Gestor del flujo de datos: chunks, slices y planificación del procesamiento."""
+"""Manage chunks, slices, and scheduling of the processing workflow."""
 from __future__ import annotations
 
 import logging
@@ -25,60 +25,28 @@ from .pipeline_parameters import (
 logger = logging.getLogger(__name__)
 
 
-# This function downsamples chunk.
 def downsample_chunk(block: np.ndarray) -> tuple[np.ndarray, float]:
-    """Aplica downsampling temporal (suma) y frecuencial (promedio) al chunk completo.
-
-    Args:
-        block: Bloque de datos original
-        
-    Returns:
-        tuple[np.ndarray, float]: (block_ds, dt_ds)
-            - block_ds: bloque decimado (tiempo, freq)
-            - dt_ds: resolución temporal efectiva (s)
-    """
+    """Apply temporal and frequency downsampling to the full chunk."""
     from ..preprocessing.data_downsampler import downsample_data
     block_ds = downsample_data(block)
     dt_ds = config.TIME_RESO * config.DOWN_TIME_RATE
     return block_ds, dt_ds
 
 
-# This function builds DM time cube.
 def build_dm_time_cube(block_ds: np.ndarray, height: int, dm_min: float, dm_max: float) -> np.ndarray:
-    """Construye el cubo DM–tiempo para el bloque decimado completo.
-    
-    Args:
-        block_ds: Bloque decimado
-        height: Altura del cubo DM
-        dm_min: DM mínimo
-        dm_max: DM máximo
-        
-    Returns:
-        np.ndarray: Cubo DM-tiempo
-    """
+    """Build the DM–time cube for the decimated block."""
     width = block_ds.shape[0]
     from ..preprocessing.dedispersion import d_dm_time_g
     return d_dm_time_g(block_ds, height=height, width=width, dm_min=dm_min, dm_max=dm_max)
 
 
-# This function trims valid window.
 def trim_valid_window(
-    block_ds: np.ndarray, 
-    dm_time_full: np.ndarray, 
-    overlap_left_ds: int, 
+    block_ds: np.ndarray,
+    dm_time_full: np.ndarray,
+    overlap_left_ds: int,
     overlap_right_ds: int
 ) -> tuple[np.ndarray, np.ndarray, int, int]:
-    """Extrae la ventana válida del bloque, eliminando bordes contaminados por solapamiento.
-    
-    Args:
-        block_ds: Bloque decimado
-        dm_time_full: Cubo DM-tiempo completo
-        overlap_left_ds: Solapamiento izquierdo decimado
-        overlap_right_ds: Solapamiento derecho decimado
-        
-    Returns:
-        tuple[np.ndarray, np.ndarray, int, int]: (block_valid, dm_time, valid_start_ds, valid_end_ds)
-    """
+    """Extract the valid window, discarding overlap-contaminated edges."""
     valid_start_ds = max(0, overlap_left_ds)
                                                          
     valid_end_ds = block_ds.shape[0]
@@ -90,18 +58,8 @@ def trim_valid_window(
     return block_valid, dm_time, valid_start_ds, valid_end_ds
 
 
-# This function plans slices.
 def plan_slices(block_valid: np.ndarray, slice_len: int, chunk_idx: int) -> list[tuple[int, int, int]]:
-    """Genera (j, start_idx, end_idx) por slice para el bloque válido.
-    
-    Args:
-        block_valid: Bloque válido (sin bordes contaminados)
-        slice_len: Longitud de cada slice
-        chunk_idx: Índice del chunk
-        
-    Returns:
-        list[tuple[int, int, int]]: Lista de tuplas (slice_idx, start_idx, end_idx)
-    """
+    """Return slice boundaries for the valid portion of the block."""
     if getattr(config, 'USE_PLANNED_CHUNKING', False):
         time_reso_ds = config.TIME_RESO * config.DOWN_TIME_RATE
         plan = plan_slices_for_chunk(
@@ -125,28 +83,15 @@ def plan_slices(block_valid: np.ndarray, slice_len: int, chunk_idx: int) -> list
 
 
 
-# This function validates slice indices.
 def validate_slice_indices(
-    start_idx: int, 
-    end_idx: int, 
-    block_shape: int, 
-    slice_len: int, 
-    j: int, 
+    start_idx: int,
+    end_idx: int,
+    block_shape: int,
+    slice_len: int,
+    j: int,
     chunk_idx: int
 ) -> tuple[bool, int, int, str]:
-    """Valida y ajusta los índices de un slice si es necesario.
-    
-    Args:
-        start_idx: Índice de inicio del slice
-        end_idx: Índice de fin del slice
-        block_shape: Tamaño del bloque
-        slice_len: Longitud esperada del slice
-        j: Índice del slice
-        chunk_idx: Índice del chunk
-        
-    Returns:
-        tuple[bool, int, int, str]: (es_valido, start_idx_ajustado, end_idx_ajustado, razon)
-    """
+    """Validate and adjust slice indices if needed."""
                                                        
     if start_idx >= block_shape:
         return False, start_idx, end_idx, "Slice fuera de límites - no hay datos que procesar"
@@ -164,22 +109,12 @@ def validate_slice_indices(
     return True, start_idx, end_idx, "Slice válido"
 
 
-# This function creates chunk directories.
 def create_chunk_directories(
-    save_dir: Path, 
-    fits_path: Path, 
+    save_dir: Path,
+    fits_path: Path,
     chunk_idx: int
 ) -> tuple[Path, Path, Path]:
-    """Crea las carpetas necesarias para un chunk específico.
-    
-    Args:
-        save_dir: Directorio base de guardado
-        fits_path: Path del archivo FITS
-        chunk_idx: Índice del chunk
-        
-    Returns:
-        tuple[Path, Path, Path]: (composite_dir, detections_dir, patches_dir)
-    """
+    """Return the directories used to store results for a given chunk."""
     file_folder_name = fits_path.stem
     chunk_folder_name = f"chunk{chunk_idx:03d}"
     
@@ -190,16 +125,8 @@ def create_chunk_directories(
     return composite_dir, detections_dir, patches_dir
 
 
-# This function gets chunk processing parameters.
 def get_chunk_processing_parameters(metadata: dict) -> dict:
-    """Obtiene todos los parámetros necesarios para procesar un chunk.
-    
-    Args:
-        metadata: Metadatos del chunk
-        
-    Returns:
-        dict: Parámetros del chunk
-    """
+    """Return derived parameters required to process a chunk."""
                                  
     chunk_samples = int(metadata.get("actual_chunk_size", config.FILE_LENG))
     freq_down = calculate_frequency_downsampled()

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -65,7 +65,6 @@ class DetectionStats:
     max_prob: float = 0.0
     snr_values: list[float] = field(default_factory=list)
 
-    # This function updates detection counters.
     def update(self, candidates: int, bursts: int, no_bursts: int, prob_max: float) -> None:
         """Update counters with the result of a slice or chunk."""
 
@@ -74,7 +73,6 @@ class DetectionStats:
         self.n_no_bursts += no_bursts
         self.max_prob = max(self.max_prob, float(prob_max))
 
-    # This function merges detection statistics.
     def merge(self, other: "DetectionStats") -> None:
         """Merge metrics coming from another :class:`DetectionStats` instance."""
 
@@ -82,11 +80,9 @@ class DetectionStats:
         if other.snr_values:
             self.snr_values.extend(other.snr_values)
 
-    # This function returns the mean SNR value.
     def mean_snr(self) -> float:
         return float(np.mean(self.snr_values)) if self.snr_values else 0.0
 
-    # This function computes effective candidate counts.
     def effective_counts(self, save_only_burst: bool) -> tuple[int, int, int]:
         """Return counts respecting the SAVE_ONLY_BURST flag."""
 
@@ -94,7 +90,6 @@ class DetectionStats:
             return self.n_bursts, self.n_bursts, 0
         return self.n_candidates, self.n_bursts, self.n_no_bursts
 
-# This function logs informational messages.
 def _trace_info(message: str, *args) -> None:
     try:
         from ..logging.logging_config import get_global_logger
@@ -103,17 +98,16 @@ def _trace_info(message: str, *args) -> None:
     except Exception:
         logger.info(message, *args)
 
-# This function optimizes memory.
 def _optimize_memory(aggressive: bool = False) -> None:
-    """Optimiza el uso de memoria del sistema.
-    
+    """Release cached resources to keep the pipeline within memory limits.
+
     Args:
-        aggressive: Si True, realiza limpieza más agresiva
+        aggressive: When ``True`` also clear GPU caches and pause briefly.
     """
-                               
+
     gc.collect()
-    
-                                                               
+
+
     if plt is not None:
         plt.close('all')                                          
     
@@ -133,7 +127,6 @@ def _optimize_memory(aggressive: bool = False) -> None:
         time.sleep(0.01)                             
 
 
-# This function loads detection model.
 def _load_detection_model() -> torch.nn.Module:
     """Load the CenterNet model configured in :mod:`config`."""
     if torch is None:
@@ -146,7 +139,6 @@ def _load_detection_model() -> torch.nn.Module:
     model.eval()
     return model
 
-# This function loads class model.
 def _load_class_model() -> torch.nn.Module:
     """Load the binary classification model configured in :mod:`config`."""
     if torch is None:
@@ -159,7 +151,6 @@ def _load_class_model() -> torch.nn.Module:
     model.eval()
     return model
 
-# This function processes block.
 def _process_block(
     det_model: torch.nn.Module,
     cls_model: torch.nn.Module,
@@ -170,7 +161,7 @@ def _process_block(
     chunk_idx: int,
     csv_file: Path,
 ) -> DetectionStats:
-    """Procesa un bloque de datos y retorna estadísticas consolidadas."""
+    """Process a data block and return aggregated detection statistics."""
 
     chunk_samples = int(metadata.get("actual_chunk_size", block.shape[0]))
     total_samples = int(metadata.get("total_samples", 0)) or chunk_samples
@@ -401,7 +392,6 @@ def _process_block(
     return chunk_stats
 
 
-# This function processes file chunked.
 def _process_file_chunked(
     det_model: torch.nn.Module,
     cls_model: torch.nn.Module,
@@ -409,7 +399,7 @@ def _process_file_chunked(
     save_dir: Path,
     chunk_samples: int,
 ) -> dict:
-    """Procesa un archivo en bloques usando stream_fil o stream_fits."""
+    """Process a file in streaming chunks using ``stream_fil`` or ``stream_fits``."""
     
                                                           
     logger.info(f"Analizando estructura del archivo: {fits_path.name}")
@@ -598,7 +588,6 @@ def _process_file_chunked(
             "error_details": str(e)
         }
 
-# This function runs pipeline.
 def run_pipeline(chunk_samples: int = 0) -> None:
     from ..logging.logging_config import setup_logging, set_global_logger
     

--- a/src/core/pipeline_parameters.py
+++ b/src/core/pipeline_parameters.py
@@ -1,45 +1,43 @@
 # This module calculates derived parameters for pipeline execution.
 
-"""Parámetros centralizados del pipeline para evitar duplicación de lógica."""
+"""Central helpers that compute derived parameters for the pipeline."""
 from __future__ import annotations
 
 import numpy as np
+
 from ..config import config
 from ..preprocessing.slice_len_calculator import update_slice_len_dynamic
 
 
-# This function calculates the downsampled frequency array.
 def calculate_frequency_downsampled() -> np.ndarray:
-    """Calcula las frecuencias decimadas del pipeline."""
+    """Return the decimated frequency axis used throughout the pipeline."""
 
     if config.FREQ is None or getattr(config, "FREQ_RESO", 0) <= 0:
-        raise ValueError("Los metadatos de frecuencia no han sido cargados")
+        raise ValueError("Frequency metadata has not been loaded")
 
     down_rate = int(getattr(config, "DOWN_FREQ_RATE", 1))
     if down_rate <= 0:
-        raise ValueError("DOWN_FREQ_RATE debe ser mayor que cero")
+        raise ValueError("DOWN_FREQ_RATE must be greater than zero")
 
     total_channels = len(config.FREQ)
     usable = total_channels - (total_channels % down_rate)
     if usable == 0:
-        raise ValueError("DOWN_FREQ_RATE es mayor que el número de canales disponibles")
+        raise ValueError("DOWN_FREQ_RATE exceeds the number of available channels")
 
     trimmed = config.FREQ[:usable]
     return trimmed.reshape(-1, down_rate).mean(axis=1)
 
 
-# This function calculates DM height.
 def calculate_dm_height() -> int:
-    """Calcula la altura del cubo DM-tiempo."""
+    """Return the DM cube height derived from the configured DM range."""
 
     dm_max = int(getattr(config, "DM_max", 0))
     dm_min = int(getattr(config, "DM_min", 0))
     return max(0, dm_max - dm_min + 1)
 
 
-# This function calculates the total decimated width.
 def calculate_width_total(total_samples: int | None = None) -> int:
-    """Calcula el ancho total decimado del archivo."""
+    """Return the total number of decimated time samples for a file."""
 
     samples = int(total_samples) if total_samples is not None else int(getattr(config, "FILE_LENG", 0))
     down_rate = int(getattr(config, "DOWN_TIME_RATE", 1))
@@ -48,93 +46,28 @@ def calculate_width_total(total_samples: int | None = None) -> int:
     return samples // down_rate
 
 
-# This function calculates slice parameters.
 def calculate_slice_parameters() -> tuple[int, float]:
-    """Calcula los parámetros de slicing dinámicamente.
-    
-    Returns:
-        tuple[int, float]: (slice_len, real_duration_ms)
-    """
+    """Return slice length and expected duration in milliseconds."""
+
     return update_slice_len_dynamic()
 
 
-# This function calculates time slice.
 def calculate_time_slice(width_total: int, slice_len: int) -> int:
-    """Calcula el número de slices para un ancho dado.
-    
-    Args:
-        width_total: Ancho total del bloque
-        slice_len: Longitud de cada slice
-        
-    Returns:
-        int: Número de slices
-    """
+    """Return how many slices are required to cover ``width_total`` samples."""
+
     return (width_total + slice_len - 1) // slice_len
 
 
-# This function calculates slice duration.
-def calculate_slice_duration(slice_len: int) -> float:
-    """Calcula la duración de un slice en segundos."""
-
-    if slice_len <= 0:
-        return 0.0
-    time_reso = float(getattr(config, "TIME_RESO", 0.0))
-    down_rate = int(getattr(config, "DOWN_TIME_RATE", 1))
-    return slice_len * time_reso * max(down_rate, 1)
-
-
-# This function gets pipeline parameters.
-def get_pipeline_parameters() -> dict:
-    """Obtiene todos los parámetros del pipeline en un solo lugar.
-    
-    Returns:
-        dict: Diccionario con todos los parámetros calculados
-    """
-    freq_down = calculate_frequency_downsampled()
-    height = calculate_dm_height()
-    width_total = calculate_width_total()
-    slice_len, real_duration_ms = calculate_slice_parameters()
-    time_slice = calculate_time_slice(width_total, slice_len)
-    slice_duration = calculate_slice_duration(slice_len)
-    
-    return {
-        'freq_down': freq_down,
-        'height': height,
-        'width_total': width_total,
-        'slice_len': slice_len,
-        'real_duration_ms': real_duration_ms,
-        'time_slice': time_slice,
-        'slice_duration': slice_duration,
-    }
-
-
-# This function calculates overlap decimated.
 def calculate_overlap_decimated(overlap_left_raw: int, overlap_right_raw: int) -> tuple[int, int]:
-    """Calcula el solapamiento en muestras decimadas.
-    
-    Args:
-        overlap_left_raw: Solapamiento izquierdo en muestras originales
-        overlap_right_raw: Solapamiento derecho en muestras originales
-        
-    Returns:
-        tuple[int, int]: (overlap_left_ds, overlap_right_ds)
-    """
-    R = int(config.DOWN_TIME_RATE)
-    overlap_left_ds = (overlap_left_raw + R - 1) // R
-    overlap_right_ds = (overlap_right_raw + R - 1) // R
+    """Return the overlap expressed in decimated samples."""
+
+    rate = int(config.DOWN_TIME_RATE)
+    overlap_left_ds = (overlap_left_raw + rate - 1) // rate
+    overlap_right_ds = (overlap_right_raw + rate - 1) // rate
     return overlap_left_ds, overlap_right_ds
 
 
-# This function calculates absolute slice time.
 def calculate_absolute_slice_time(chunk_start_time_sec: float, start_idx: int, dt_ds: float) -> float:
-    """Calcula el tiempo absoluto de inicio de un slice.
-    
-    Args:
-        chunk_start_time_sec: Tiempo de inicio del chunk
-        start_idx: Índice de inicio del slice
-        dt_ds: Resolución temporal decimada
-        
-    Returns:
-        float: Tiempo absoluto del slice en segundos
-    """
+    """Return the absolute start time of a slice in seconds."""
+
     return chunk_start_time_sec + (start_idx * dt_ds)

--- a/src/detection/model_interface.py
+++ b/src/detection/model_interface.py
@@ -25,7 +25,6 @@ except ImportError:
               
 logger = logging.getLogger(__name__)
 
-# This function runs the detection model.
 def detect(model, img_tensor: np.ndarray):
     """Run the detection model and return confidences and boxes."""
     if get_res is None:
@@ -60,7 +59,6 @@ def detect(model, img_tensor: np.ndarray):
         logger.error(f"Error en detect: {e}")
         return [], []
 
-# This function preps patch.
 def prep_patch(patch: np.ndarray) -> np.ndarray:
     """Normalize patch for classification."""
     patch = patch.copy()
@@ -71,7 +69,6 @@ def prep_patch(patch: np.ndarray) -> np.ndarray:
     patch = (patch - patch.min()) / (patch.max() - patch.min())
     return patch
 
-# This function classifies patch.
 def classify_patch(model, patch: np.ndarray):
     """Return probability from binary model for patch along with the processed patch."""
     proc = prep_patch(patch)

--- a/src/input/data_loader.py
+++ b/src/input/data_loader.py
@@ -67,87 +67,32 @@ from .streaming_orchestrator import get_streaming_function
               
 logger = logging.getLogger(__name__)
 
-                                                                               
-                                                           
-                                                                               
 
-# This function returns a safe float value.
 def _safe_float(value, default=0.0):
     """Return ``value`` as ``float`` or ``default`` if conversion fails."""
     return safe_float(value, default)
 
 
-# This function returns a safe integer value.
 def _safe_int(value, default=0):
     """Return ``value`` as ``int`` or ``default`` if conversion fails."""
     return safe_int(value, default)
 
 
-# This function auto-configures downsampling parameters.
 def _auto_config_downsampling() -> None:
-    """Configura DOWN_FREQ_RATE y DOWN_TIME_RATE si no fueron fijados por el usuario."""
+    """Configure ``DOWN_FREQ_RATE`` and ``DOWN_TIME_RATE`` when not provided."""
     auto_config_downsampling()
 
 
-# This function prints debug frequencies.
 def _print_debug_frequencies(prefix: str, file_name: str, freq_axis_inverted: bool) -> None:
-    """Imprime bloque estándar de depuración de frecuencias con un prefijo dado."""
+    """Print the standard frequency debug block with a prefixed label."""
     print_debug_frequencies(prefix, file_name, freq_axis_inverted)
 
 
-# This function saves file debug info.
 def _save_file_debug_info(file_name: str, debug_info: dict) -> None:
-    """Guarda debug info (FITS o FIL) en summary.json inmediatamente (unificado)."""
+    """Persist file debug information in ``summary.json`` immediately."""
     save_file_debug_info(file_name, debug_info)
 
                                                                                
                                  
                                                                                
-"""
-ESTRUCTURA REFACTORIZADA:
 
-1. MÓDULO UTILS (src/input/utils.py):
-   - safe_float() → _safe_float() (compatibilidad)
-   - safe_int() → _safe_int() (compatibilidad)
-   - auto_config_downsampling() → _auto_config_downsampling() (compatibilidad)
-   - print_debug_frequencies() → _print_debug_frequencies() (compatibilidad)
-   - save_file_debug_info() → _save_file_debug_info() (compatibilidad)
-
-2. MÓDULO FITS_HANDLER (src/input/fits_handler.py):
-   - load_fits_file() → importado directamente
-   - get_obparams() → importado directamente
-   - stream_fits() → importado directamente
-
-3. MÓDULO FILTERBANK_HANDLER (src/input/filterbank_handler.py):
-   - _read_int() → importado directamente
-   - _read_double() → importado directamente
-   - _read_string() → importado directamente
-   - _read_header() → importado directamente
-   - _read_non_standard_header() → importado directamente
-   - load_fil_file() → importado directamente
-   - get_obparams_fil() → importado directamente
-   - stream_fil() → importado directamente
-
-4. NUEVOS MÓDULOS INTELIGENTES:
-   - file_detector.py: Detección y validación de tipos de archivo
-   - parameter_extractor.py: Extracción automática de parámetros
-   - streaming_orchestrator.py: Orquestación inteligente de streaming
-
-5. WRAPPER PRINCIPAL (src/input/data_loader.py):
-   - Mantiene todas las funciones públicas para compatibilidad
-   - Importa funciones de los módulos especializados
-   - Proporciona funciones de compatibilidad con prefijo _
-   - Expone nuevas funciones inteligentes
-
-BENEFICIOS DE LA REFACTORIZACIÓN:
-- Código más modular y mantenible
-- Separación clara de responsabilidades
-- Fácil testing y debugging por módulo
-- Compatibilidad total con el pipeline existente
-- Mejor organización del código
-- Reutilización de funciones comunes
-- Funciones inteligentes para detección automática
-
-NOTA: Todas las funciones públicas del módulo original siguen disponibles
-con la misma interfaz, por lo que el pipeline existente no se verá afectado.
-"""

--- a/src/input/file_detector.py
+++ b/src/input/file_detector.py
@@ -1,12 +1,6 @@
 # This module determines file types and validates compatibility.
 
-"""Detector y clasificador de tipos de archivos astronómicos.
-
-Este módulo se encarga de:
-1. Detectar automáticamente el tipo de archivo basado en extensión y contenido
-2. Validar que el archivo sea compatible con el pipeline
-3. Proporcionar información sobre el formato detectado
-"""
+"""Detect and validate astronomical file formats used by the pipeline."""
 
 from pathlib import Path
 from typing import Dict, Any
@@ -18,19 +12,10 @@ logger = logging.getLogger(__name__)
 SUPPORTED_EXTENSIONS = {'.fits', '.fil'}
 SUPPORTED_FORMATS = {'fits', 'filterbank'}
 
-# This function detects file type.
 def detect_file_type(file_path: Path) -> str:
-    """
-    Detecta automáticamente el tipo de archivo basado en su extensión.
-    
-    Args:
-        file_path: Path al archivo a analizar
-        
-    Returns:
-        str: Tipo de archivo detectado ('fits' o 'filterbank')
-        
-    Raises:
-        ValueError: Si el tipo de archivo no es soportado
+    """Detect the file type from its suffix.
+
+    Raises ``ValueError`` when the extension is unsupported.
     """
     suffix = file_path.suffix.lower()
     
@@ -40,27 +25,13 @@ def detect_file_type(file_path: Path) -> str:
         return "filterbank"
     else:
         raise ValueError(
-            f"Tipo de archivo no soportado: {file_path}\n"
-            f"Extensión detectada: {suffix}\n"
-            f"Extensiones soportadas: {', '.join(SUPPORTED_EXTENSIONS)}"
+            f"Unsupported file type: {file_path}\n"
+            f"Detected extension: {suffix}\n"
+            f"Supported extensions: {', '.join(SUPPORTED_EXTENSIONS)}"
         )
 
-# This function validates file compatibility.
 def validate_file_compatibility(file_path: Path) -> Dict[str, Any]:
-    """
-    Valida que el archivo sea compatible con el pipeline.
-    
-    Args:
-        file_path: Path al archivo a validar
-        
-    Returns:
-        Dict con información de validación:
-        - is_compatible: bool
-        - file_type: str
-        - extension: str
-        - size_bytes: int
-        - validation_errors: List[str]
-    """
+    """Validate whether a file can be processed by the pipeline."""
     validation_result = {
         'is_compatible': False,
         'file_type': None,
@@ -72,12 +43,12 @@ def validate_file_compatibility(file_path: Path) -> Dict[str, Any]:
     try:
                                          
         if not file_path.exists():
-            validation_result['validation_errors'].append(f"Archivo no encontrado: {file_path}")
+            validation_result['validation_errors'].append(f"File not found: {file_path}")
             return validation_result
         
                                                      
         if not file_path.is_file():
-            validation_result['validation_errors'].append(f"Path no es un archivo: {file_path}")
+            validation_result['validation_errors'].append(f"Path is not a file: {file_path}")
             return validation_result
         
                                   
@@ -97,7 +68,7 @@ def validate_file_compatibility(file_path: Path) -> Dict[str, Any]:
             validation_result['size_bytes'] = size_bytes
             
             if size_bytes == 0:
-                validation_result['validation_errors'].append("Archivo vacío (0 bytes)")
+                validation_result['validation_errors'].append("Empty file (0 bytes)")
                 return validation_result
                 
                                                             
@@ -105,13 +76,13 @@ def validate_file_compatibility(file_path: Path) -> Dict[str, Any]:
                 logger.warning(f"Archivo muy grande detectado: {size_bytes / (1024**3):.1f} GB")
                 
         except OSError as e:
-            validation_result['validation_errors'].append(f"Error accediendo al archivo: {e}")
+            validation_result['validation_errors'].append(f"Error accessing file: {e}")
             return validation_result
         
                                                     
         validation_result['is_compatible'] = True
         
     except Exception as e:
-        validation_result['validation_errors'].append(f"Error inesperado durante validación: {e}")
+        validation_result['validation_errors'].append(f"Unexpected validation error: {e}")
     
     return validation_result

--- a/src/input/file_finder.py
+++ b/src/input/file_finder.py
@@ -1,13 +1,6 @@
 # This module locates input data files for processing.
 
-"""Buscador y filtrador de archivos astronómicos.
-
-Este módulo se encarga de:
-1. Buscar archivos FITS y filterbank en directorios
-2. Filtrar archivos por criterios específicos (nombre, tipo, tamaño)
-3. Validar que los archivos encontrados sean compatibles
-4. Proporcionar información sobre los archivos encontrados
-"""
+"""Locate and filter FITS or filterbank files relevant to a target."""
 
 from pathlib import Path
 from typing import List, Optional
@@ -18,31 +11,18 @@ from ..config import config
 
 logger = logging.getLogger(__name__)
 
-# This function finds data files.
 def find_data_files(frb_target: str, data_dir: Optional[Path] = None) -> List[Path]:
-    """
-    Busca archivos FITS o filterbank que coincidan con el target FRB.
-    
-    Args:
-        frb_target: Target FRB a buscar en los nombres de archivo
-        data_dir: Directorio de datos (usa config.DATA_DIR si no se especifica)
-        
-    Returns:
-        Lista ordenada de archivos compatibles encontrados
-        
-    Raises:
-        ValueError: Si el directorio no existe o no hay archivos compatibles
-    """
+    """Return FITS or filterbank files whose names contain ``frb_target``."""
     if data_dir is None:
         data_dir = config.DATA_DIR
     
     if not data_dir.exists():
-        raise ValueError(f"Directorio de datos no existe: {data_dir}")
-    
+        raise ValueError(f"Data directory does not exist: {data_dir}")
+
     if not data_dir.is_dir():
-        raise ValueError(f"Path no es un directorio: {data_dir}")
-    
-    logger.info(f"Buscando archivos para target '{frb_target}' en: {data_dir}")
+        raise ValueError(f"Path is not a directory: {data_dir}")
+
+    logger.info(f"Searching files for target '{frb_target}' in: {data_dir}")
     
                                    
     fits_files = list(data_dir.glob("*.fits"))
@@ -51,22 +31,22 @@ def find_data_files(frb_target: str, data_dir: Optional[Path] = None) -> List[Pa
     all_files = fits_files + fil_files
     
     if not all_files:
-        logger.warning(f"No se encontraron archivos .fits o .fil en: {data_dir}")
+        logger.warning(f"No .fits or .fil files found in: {data_dir}")
         return []
-    
-    logger.info(f"Archivos encontrados: {len(fits_files)} .fits, {len(fil_files)} .fil")
+
+    logger.info(f"Files found: {len(fits_files)} .fits, {len(fil_files)} .fil")
     
                             
     matching_files = [f for f in all_files if frb_target.lower() in f.name.lower()]
     
     if not matching_files:
-        logger.warning(f"No se encontraron archivos que coincidan con target '{frb_target}'")
+        logger.warning(f"No files match target '{frb_target}'")
         return []
     
                         
     matching_files.sort(key=lambda x: x.name)
     
-    logger.info(f"Archivos coincidentes encontrados: {len(matching_files)}")
+    logger.info(f"Matching files found: {len(matching_files)}")
     for file in matching_files:
         logger.debug(f"  - {file.name}")
     

--- a/src/input/filterbank_handler.py
+++ b/src/input/filterbank_handler.py
@@ -1,6 +1,6 @@
 # This module handles SIGPROC filterbank file ingestion.
 
-"""Manejo de archivos filterbank (.fil) para el pipeline de detección de FRBs."""
+"""Manage SIGPROC filterbank (.fil) files for the FRB detection pipeline."""
 from __future__ import annotations
 
 import gc
@@ -20,26 +20,22 @@ from ..logging import (
 from .utils import safe_float, safe_int, auto_config_downsampling, print_debug_frequencies, save_file_debug_info
 
 
-# This function reads int.
 def _read_int(f) -> int:
-    """Lee un entero de 32 bits del archivo."""
+    """Read a 32-bit integer from the file."""
     return struct.unpack("<i", f.read(4))[0]
 
 
-# This function reads double.
 def _read_double(f) -> float:
-    """Lee un double de 64 bits del archivo."""
+    """Read a 64-bit floating-point value from the file."""
     return struct.unpack("<d", f.read(8))[0]
 
 
-# This function reads string.
 def _read_string(f) -> str:
-    """Lee una cadena de caracteres del archivo."""
+    """Read a length-prefixed string from the file."""
     length = _read_int(f)
     return f.read(length).decode('utf-8', errors='ignore')
 
 
-# This function reads header.
 def _read_header(f) -> Tuple[dict, int]:
     """Read filterbank header, handling both standard and non-standard formats."""
     original_pos = f.tell()
@@ -99,7 +95,6 @@ def _read_header(f) -> Tuple[dict, int]:
         return _read_non_standard_header(f)
 
 
-# This function reads non standard header.
 def _read_non_standard_header(f) -> Tuple[dict, int]:
     """Handle non-standard filterbank files by assuming common parameters."""
     print("[INFO] Detectado archivo .fil con formato no estándar, usando parámetros estimados")
@@ -134,7 +129,6 @@ def _read_non_standard_header(f) -> Tuple[dict, int]:
     return header, 512
 
 
-# This function loads filterbank file.
 def load_fil_file(file_name: str) -> np.ndarray:
     """Load a filterbank file and return the data array in shape (time, pol, channel)."""
     global_vars = config
@@ -219,7 +213,6 @@ def load_fil_file(file_name: str) -> np.ndarray:
     return data_array
 
 
-# This function gets obparams filterbank.
 def get_obparams_fil(file_name: str) -> None:
     """Extract observation parameters and populate :mod:`config`."""
     
@@ -454,7 +447,6 @@ def get_obparams_fil(file_name: str) -> None:
         })
 
 
-# This function streams filterbank.
 def stream_fil(
     file_name: str,
     chunk_samples: int = 2_097_152,

--- a/src/input/fits_handler.py
+++ b/src/input/fits_handler.py
@@ -32,9 +32,8 @@ from ..logging import (
 from .utils import safe_float, safe_int, auto_config_downsampling, print_debug_frequencies, save_file_debug_info
 
 
-# This function unpacks 1 bit data.
 def _unpack_1bit(data: np.ndarray) -> np.ndarray:
-    """Desempaqueta datos de 1 bit contenidos en bytes a uint8."""
+    """Unpack 1-bit samples stored in bytes into ``uint8`` values."""
     b0 = (data >> 0x07) & 0x01
     b1 = (data >> 0x06) & 0x01
     b2 = (data >> 0x05) & 0x01
@@ -46,9 +45,8 @@ def _unpack_1bit(data: np.ndarray) -> np.ndarray:
     return np.dstack([b0, b1, b2, b3, b4, b5, b6, b7]).flatten()
 
 
-# This function unpacks 2 bit data.
 def _unpack_2bit(data: np.ndarray) -> np.ndarray:
-    """Desempaqueta datos de 2 bits contenidos en bytes a uint8."""
+    """Unpack 2-bit samples stored in bytes into ``uint8`` values."""
     p0 = (data >> 0x06) & 0x03
     p1 = (data >> 0x04) & 0x03
     p2 = (data >> 0x02) & 0x03
@@ -56,15 +54,13 @@ def _unpack_2bit(data: np.ndarray) -> np.ndarray:
     return np.dstack([p0, p1, p2, p3]).flatten()
 
 
-# This function unpacks 4 bit data.
 def _unpack_4bit(data: np.ndarray) -> np.ndarray:
-    """Desempaqueta datos de 4 bits contenidos en bytes a uint8."""
+    """Unpack 4-bit samples stored in bytes into ``uint8`` values."""
     p0 = (data >> 0x04) & 0x0F
     p1 = data & 0x0F
     return np.dstack([p0, p1]).flatten()
 
 
-# This function applies calibration.
 def _apply_calibration(
     data: np.ndarray,
     dat_wts: np.ndarray | None,
@@ -72,12 +68,18 @@ def _apply_calibration(
     dat_offs: np.ndarray | None,
     zero_off: float,
 ) -> np.ndarray:
-    """Aplica correcciones PSRFITS al bloque de datos.
+    """Apply PSRFITS calibration to a data block.
 
-    Espera `data` como float32 con shape (nsblk, npol, nchan).
-    - dat_wts: (nchan,)
-    - dat_scl: (npol*nchan,)
-    - dat_offs: (npol*nchan,)
+    Parameters
+    ----------
+    data : np.ndarray
+        Float32 array with shape ``(nsblk, npol, nchan)``.
+    dat_wts : np.ndarray | None
+        Channel weights ``(nchan,)``.
+    dat_scl : np.ndarray | None
+        Scale factors ``(npol * nchan,)``.
+    dat_offs : np.ndarray | None
+        Offsets ``(npol * nchan,)``.
     """
     if data.dtype != np.float32:
         data = data.astype(np.float32, copy=False)
@@ -100,7 +102,6 @@ def _apply_calibration(
     return data
 
 
-# This function selects polarization.
 def _select_polarization(
     data: np.ndarray,
     pol_type: str,
@@ -156,7 +157,6 @@ def _select_polarization(
     return data[:, default_index:default_index + 1, :]
 
 
-# This function loads FITS file.
 def load_fits_file(file_name: str) -> np.ndarray:
     """Load a FITS file and return the data array in shape (time, pol, channel)."""
     global_vars = config
@@ -448,7 +448,6 @@ def load_fits_file(file_name: str) -> np.ndarray:
     return data_array
 
 
-# This function gets obparams.
 def get_obparams(file_name: str) -> None:
     """Extract observation parameters and populate :mod:`config`."""
     
@@ -854,7 +853,6 @@ def get_obparams(file_name: str) -> None:
         })
 
 
-# This function streams FITS.
 def stream_fits(
     file_name: str,
     chunk_samples: int = 2_097_152,
@@ -873,7 +871,6 @@ def stream_fits(
     """
     
                                                                                         
-    # This function converts a SUBINT row into a data block.
     def _row_to_block(row_data: np.ndarray, row: np.ndarray, subint, nbits: int, nsblk: int, npol: int, nchan: int, zero_off: float, pol_type: str) -> np.ndarray:
                                                         
         if nbits < 8:
@@ -1040,7 +1037,6 @@ def stream_fits(
                                                                                 
 
                                                                                                         
-                    # This function estimates the expected start sample.
                     def _expected_start_sample(offs_sub_seconds: float, sub_index: int) -> int:
                         if offs_sub_seconds is not None:
                                                                     

--- a/src/input/utils.py
+++ b/src/input/utils.py
@@ -1,6 +1,6 @@
 # This module provides utility conversions for input processing.
 
-"""Utilidades comunes para el manejo de archivos astronómicos (FITS, filterbank)."""
+"""Common utilities used while handling FITS and filterbank files."""
 from __future__ import annotations
 
 import os
@@ -12,7 +12,6 @@ from ..config import config
 from ..output.summary_manager import _update_summary_with_file_debug
 
 
-# This function returns a safe float value.
 def safe_float(value, default=0.0) -> float:
     """Return ``value`` as ``float`` or ``default`` if conversion fails."""
     try:
@@ -25,7 +24,6 @@ def safe_float(value, default=0.0) -> float:
             return default
 
 
-# This function returns a safe integer value.
 def safe_int(value, default=0) -> int:
     """Return ``value`` as ``int`` or ``default`` if conversion fails."""
     try:
@@ -38,9 +36,8 @@ def safe_int(value, default=0) -> int:
             return default
 
 
-# This function auto-configures downsampling parameters.
 def auto_config_downsampling() -> None:
-    """Configura DOWN_FREQ_RATE y DOWN_TIME_RATE si no fueron fijados por el usuario."""
+    """Configure downsampling factors when the user did not override them."""
     user_configured_freq = getattr(config, 'DOWN_FREQ_RATE', None)
     user_configured_time = getattr(config, 'DOWN_TIME_RATE', None)
 
@@ -57,33 +54,31 @@ def auto_config_downsampling() -> None:
             config.DOWN_TIME_RATE = 15
 
 
-# This function prints debug frequencies.
 def print_debug_frequencies(prefix: str, file_name: str, freq_axis_inverted: bool) -> None:
-    """Imprime bloque estándar de depuración de frecuencias con un prefijo dado."""
-    print(f"{prefix} Archivo: {file_name}")
-    print(f"{prefix} freq_axis_inverted detectado: {freq_axis_inverted}")
-    print(f"{prefix} DATA_NEEDS_REVERSAL configurado: {config.DATA_NEEDS_REVERSAL}")
-    print(f"{prefix} Primeras 5 frecuencias: {config.FREQ[:5]}")
-    print(f"{prefix} Últimas 5 frecuencias: {config.FREQ[-5:]}")
-    print(f"{prefix} Frecuencia mínima: {config.FREQ.min():.2f} MHz")
-    print(f"{prefix} Frecuencia máxima: {config.FREQ.max():.2f} MHz")
-    print(f"{prefix} Orden esperado: frecuencias ASCENDENTES (menor a mayor)")
+    """Print a standard frequency debug block with the given prefix."""
+    print(f"{prefix} File: {file_name}")
+    print(f"{prefix} Detected freq_axis_inverted: {freq_axis_inverted}")
+    print(f"{prefix} DATA_NEEDS_REVERSAL: {config.DATA_NEEDS_REVERSAL}")
+    print(f"{prefix} First 5 frequencies: {config.FREQ[:5]}")
+    print(f"{prefix} Last 5 frequencies: {config.FREQ[-5:]}")
+    print(f"{prefix} Minimum frequency: {config.FREQ.min():.2f} MHz")
+    print(f"{prefix} Maximum frequency: {config.FREQ.max():.2f} MHz")
+    print(f"{prefix} Expected order: ascending frequencies")
     if config.FREQ[0] < config.FREQ[-1]:
-        print(f"{prefix} Orden CORRECTO: {config.FREQ[0]:.2f} < {config.FREQ[-1]:.2f}")
+        print(f"{prefix} Order CORRECT: {config.FREQ[0]:.2f} < {config.FREQ[-1]:.2f}")
     else:
-        print(f"{prefix} Orden INCORRECTO: {config.FREQ[0]:.2f} > {config.FREQ[-1]:.2f}")
+        print(f"{prefix} Order INCORRECT: {config.FREQ[0]:.2f} > {config.FREQ[-1]:.2f}")
     print(f"{prefix} DOWN_FREQ_RATE: {config.DOWN_FREQ_RATE}")
     print(f"{prefix} DOWN_TIME_RATE: {config.DOWN_TIME_RATE}")
     print(f"{prefix} " + "="*50)
 
 
-# This function saves file debug info.
 def save_file_debug_info(file_name: str, debug_info: Dict) -> None:
-    """Guarda debug info (FITS o FIL) en summary.json inmediatamente (unificado)."""
+    """Persist debug information (FITS or FIL) into ``summary.json`` immediately."""
     try:
         results_dir = getattr(config, 'RESULTS_DIR', Path('./Results'))
         results_dir.mkdir(parents=True, exist_ok=True)
         filename = Path(file_name).stem
         _update_summary_with_file_debug(results_dir, filename, debug_info)
     except Exception as e:
-        print(f"[WARNING] Error guardando debug info para {file_name}: {e}")
+        print(f"[WARNING] Error saving debug info for {file_name}: {e}")

--- a/src/logging/chunking_logging.py
+++ b/src/logging/chunking_logging.py
@@ -15,7 +15,6 @@ from typing import Any, Dict
 from .logging_config import get_global_logger
 
 
-# This function displays detailed chunking info.
 def display_detailed_chunking_info(parameters: Dict[str, Any]) -> None:
     """
     Muestra información detallada del sistema de chunking en consola.
@@ -106,7 +105,6 @@ def display_detailed_chunking_info(parameters: Dict[str, Any]) -> None:
     logger.logger.info("=" * 80)
 
 
-# This function logs chunk processing start.
 def log_chunk_processing_start(chunk_idx: int, chunk_info: Dict[str, Any]) -> None:
     """
     Registra el inicio del procesamiento de un chunk.
@@ -121,7 +119,6 @@ def log_chunk_processing_start(chunk_idx: int, chunk_info: Dict[str, Any]) -> No
     logger.logger.info(f"   • Slices en chunk: {chunk_info.get('slices_per_chunk', 0)}")
 
 
-# This function logs chunk processing end.
 def log_chunk_processing_end(chunk_idx: int, results: Dict[str, Any]) -> None:
     """
     Registra el fin del procesamiento de un chunk.
@@ -136,7 +133,6 @@ def log_chunk_processing_end(chunk_idx: int, results: Dict[str, Any]) -> None:
     logger.logger.info(f"   • Tiempo de procesamiento: {results.get('processing_time', 0):.2f} s")
 
 
-# This function logs file processing summary.
 def log_file_processing_summary(file_info: Dict[str, Any]) -> None:
     """
     Registra un resumen del procesamiento del archivo.
@@ -153,7 +149,6 @@ def log_file_processing_summary(file_info: Dict[str, Any]) -> None:
     logger.logger.info(f"   • Tiempo total: {file_info.get('total_time', 0):.2f} s")
 
 
-# This function logs memory optimization.
 def log_memory_optimization(optimization_info: Dict[str, Any]) -> None:
     """
     Registra información sobre optimizaciones de memoria.
@@ -168,7 +163,6 @@ def log_memory_optimization(optimization_info: Dict[str, Any]) -> None:
     logger.logger.info(f"   • Eficiencia: {optimization_info.get('efficiency_percent', 0):.1f}%")
 
 
-# This function logs slice configuration.
 def log_slice_configuration(slice_config: Dict[str, Any]) -> None:
     """
     Registra la configuración de slices.
@@ -184,7 +178,6 @@ def log_slice_configuration(slice_config: Dict[str, Any]) -> None:
     logger.logger.info(f"   • Precisión: {slice_config.get('precision_percent', 0):.1f}%")
 
 
-# This function logs chunk budget.
 def log_chunk_budget(budget: Dict[str, Any]) -> None:
     """
     Registra el presupuesto de memoria y cálculo de tamaño de chunk cuando el planificador está activo.
@@ -213,7 +206,6 @@ def log_chunk_budget(budget: Dict[str, Any]) -> None:
     logger.logger.info(f"   • Downsampling: tiempo={budget.get('down_time_rate', 1)}x, freq={budget.get('down_freq_rate', 1)}x")
 
 
-# This function logs slice plan summary.
 def log_slice_plan_summary(chunk_idx: int, plan: Dict[str, Any]) -> None:
     """Registra un resumen del plan de slices para un chunk.
 

--- a/src/logging/data_loader_logging.py
+++ b/src/logging/data_loader_logging.py
@@ -16,7 +16,6 @@ from typing import Any, Dict, Optional
 from .logging_config import get_global_logger
 
 
-# This function logs stream filterbank parameters.
 def log_stream_fil_parameters(nsamples: int, chunk_samples: int, overlap_samples: int, 
                              nchans: int, nifs: int, nbits: int, dtype: str) -> None:
     """
@@ -36,7 +35,6 @@ def log_stream_fil_parameters(nsamples: int, chunk_samples: int, overlap_samples
     logger.logger.debug(f"[DEBUG] STREAM_FIL: nchans={nchans}, nifs={nifs}, nbits={nbits}, dtype={dtype}")
 
 
-# This function logs stream filterbank block generation.
 def log_stream_fil_block_generation(chunk_counter: int, block_shape: tuple, block_dtype: str,
                                    valid_start: int, valid_end: int, 
                                    start_with_overlap: int, end_with_overlap: int,
@@ -61,7 +59,6 @@ def log_stream_fil_block_generation(chunk_counter: int, block_shape: tuple, bloc
     logger.logger.debug(f"[DEBUG] STREAM_FIL BLOQUE {chunk_counter}: actual_chunk_size={actual_chunk_size:,}")
 
 
-# This function logs the filterbank streaming summary.
 def log_stream_fil_summary(chunk_counter: int) -> None:
     """
     Registra el resumen de streaming FIL.
@@ -74,7 +71,6 @@ def log_stream_fil_summary(chunk_counter: int) -> None:
     logger.logger.debug(f"[DEBUG] STREAM_FIL RESUMEN: archivo procesado completamente a través de streaming")
 
 
-# This function logs stream FITS parameters.
 def log_stream_fits_parameters(nsamples: int, chunk_samples: int, overlap_samples: int,
                               nsubint: Optional[int], nchan: Optional[int], 
                               npol: Optional[int], nsblk: Optional[int]) -> None:
@@ -96,7 +92,6 @@ def log_stream_fits_parameters(nsamples: int, chunk_samples: int, overlap_sample
     logger.logger.debug(f"[DEBUG] STREAM_FITS: npol={npol if npol is not None else 'N/A'}, nsblk={nsblk if nsblk is not None else 'N/A'}")
 
 
-# This function logs stream FITS load strategy.
 def log_stream_fits_load_strategy(use_memmap: bool, data_shape: tuple, data_dtype: str) -> None:
     """
     Registra la estrategia de carga para archivos FITS.
@@ -111,7 +106,6 @@ def log_stream_fits_load_strategy(use_memmap: bool, data_shape: tuple, data_dtyp
     logger.logger.debug(f"[DEBUG] STREAM_FITS CARGA: data_array.dtype={data_dtype}")
 
 
-# This function logs stream FITS block generation.
 def log_stream_fits_block_generation(chunk_counter: int, block_shape: tuple, block_dtype: str,
                                     valid_start: int, valid_end: int,
                                     start_with_overlap: int, end_with_overlap: int,
@@ -136,7 +130,6 @@ def log_stream_fits_block_generation(chunk_counter: int, block_shape: tuple, blo
     logger.logger.debug(f"[DEBUG] STREAM_FITS BLOQUE {chunk_counter}: actual_chunk_size={actual_chunk_size:,}")
 
 
-# This function logs stream FITS summary.
 def log_stream_fits_summary(chunk_counter: int) -> None:
     """
     Registra el resumen de streaming FITS.

--- a/src/logging/gpu_logging.py
+++ b/src/logging/gpu_logging.py
@@ -18,13 +18,11 @@ logger = logging.getLogger(__name__)
                                         
 GPU_VERBOSE = False                                                  
 
-# This function sets GPU verbose.
 def set_gpu_verbose(verbose: bool = False):
     """Configura si mostrar mensajes detallados de GPU."""
     global GPU_VERBOSE
     GPU_VERBOSE = verbose
 
-# This function manages the GPU logging context.
 def gpu_context(operation: str, suppress_messages: bool = True):
     """
     Context manager para operaciones GPU que suprime mensajes innecesarios.
@@ -52,7 +50,6 @@ def gpu_context(operation: str, suppress_messages: bool = True):
     else:
         yield
 
-# This function logs GPU operation.
 def log_gpu_operation(operation: str, success: bool = True, details: Optional[str] = None):
     """
     Log de operaciones GPU de manera limpia.
@@ -79,7 +76,6 @@ def log_gpu_operation(operation: str, success: bool = True, details: Optional[st
         else:
             logger.error(f"{operation}")
 
-# This function logs GPU memory operation.
 def log_gpu_memory_operation(operation: str, bytes_allocated: int = 0):
     """
     Log de operaciones de memoria GPU de manera simplificada.
@@ -109,7 +105,6 @@ def log_gpu_memory_operation(operation: str, bytes_allocated: int = 0):
             logger.debug(f"{operation}")
 
                                                 
-# This function filters cuda messages.
 def filter_cuda_messages(message: str) -> bool:
     """
     Filtra mensajes CUDA para mostrar solo los relevantes.

--- a/src/logging/logging_config.py
+++ b/src/logging/logging_config.py
@@ -47,7 +47,6 @@ class Colors:
 class DRAFTSFormatter(logging.Formatter):
     """Formateador personalizado para DRAFTS con colores y estructura."""
     
-    # This function initializes the formatter.
     def __init__(self, use_colors: bool = True):
         super().__init__()
         self.use_colors = use_colors
@@ -61,42 +60,36 @@ class DRAFTSFormatter(logging.Formatter):
             logging.CRITICAL: self._format_critical,
         }
     
-    # This function formats log records.
     def format(self, record):
         """Aplica formato según el nivel del log."""
         if record.levelno in self.formats:
             return self.formats[record.levelno](record)
         return super().format(record)
     
-    # This function formats debug messages.
     def _format_debug(self, record):
         """Formato para mensajes DEBUG."""
         if self.use_colors:
             return f"{Colors.OKCYAN} [DEBUG] {record.getMessage()}{Colors.ENDC}"
         return f"[DEBUG] {record.getMessage()}"
     
-    # This function formats info messages.
     def _format_info(self, record):
         """Formato para mensajes INFO."""
         if self.use_colors:
             return f"{Colors.OKGREEN}[INFO] {record.getMessage()}{Colors.ENDC}"
         return f"[INFO] {record.getMessage()}"
     
-    # This function formats warning messages.
     def _format_warning(self, record):
         """Formato para mensajes WARNING."""
         if self.use_colors:
             return f"{Colors.WARNING}[WARN] {record.getMessage()}{Colors.ENDC}"
         return f"{record.getMessage()}"
     
-    # This function formats error messages.
     def _format_error(self, record):
         """Formato para mensajes ERROR."""
         if self.use_colors:
             return f"{Colors.ERROR}[ERROR] {record.getMessage()}{Colors.ENDC}"
         return f"[ERROR] {record.getMessage()}"
     
-    # This function formats critical messages.
     def _format_critical(self, record):
         """Formato para mensajes CRITICAL."""
         if self.use_colors:
@@ -107,7 +100,6 @@ class DRAFTSFormatter(logging.Formatter):
 class DRAFTSLogger:
     """Logger principal para DRAFTS con funcionalidades especializadas."""
     
-    # This function initializes the logger.
     def __init__(self, name: str = "DRAFTS", level: str = "INFO", 
                  log_file: Optional[Path] = None, use_colors: bool = True):
         self.logger = logging.getLogger(name)
@@ -138,7 +130,6 @@ class DRAFTSLogger:
                                        
         self.logger.info(f"Logs guardándose en: {log_file.absolute()}")
     
-    # This function logs pipeline startup information.
     def pipeline_start(self, config: Dict[str, Any]):
         """Log del inicio del pipeline."""
         self.logger.info(f"{Colors.PIPELINE}INICIANDO PIPELINE DE DETECCIÓN DE FRB{Colors.ENDC}")
@@ -161,7 +152,6 @@ class DRAFTSLogger:
         if config.get('chunk_samples', 0) > 0:
             self.logger.info(f"Chunking: {config['chunk_samples']:,} muestras/bloque")
     
-    # This function logs pipeline completion details.
     def pipeline_end(self, summary: Dict[str, Any]):
         """Log del fin del pipeline."""
         total_files = len(summary)
@@ -173,7 +163,6 @@ class DRAFTSLogger:
         self.logger.info(f"Resumen: {total_files} archivos, {total_candidates} candidatos, {total_bursts} bursts")
         self.logger.info(f"Tiempo total: {total_time:.1f}s")
     
-    # This function logs the start of file processing.
     def file_processing_start(self, filename: str, file_info: Dict[str, Any]):
         """Log del inicio de procesamiento de archivo."""
         self.logger.info(f"{Colors.FILE} Procesando: {filename}{Colors.ENDC}")
@@ -181,28 +170,24 @@ class DRAFTSLogger:
         self.logger.info(f"Duración: {file_info.get('duration_min', 0):.1f} min")
         self.logger.info(f"Canales: {file_info.get('channels', 0)}")
     
-    # This function logs the end of file processing.
     def file_processing_end(self, filename: str, results: Dict[str, Any]):
         """Log del fin de procesamiento de archivo."""
         self.logger.info(f"{Colors.FILE} {filename}: {results.get('n_candidates', 0)} candidatos, "
                         f"max prob {results.get('max_prob', 0):.2f}, "
                         f"{results.get('runtime_s', 0):.1f}s{Colors.ENDC}")
     
-    # This function logs chunk processing.
     def chunk_processing(self, chunk_idx: int, chunk_info: Dict[str, Any]):
         """Log del procesamiento de chunk."""
         self.logger.info(f"{Colors.PROCESSING} Chunk {chunk_idx:03d}: "
                         f"{chunk_info.get('samples', 0):,} muestras → "
                         f"{chunk_info.get('slices', 0)} slices{Colors.ENDC}")
     
-    # This function logs slice processing.
     def slice_processing(self, slice_idx: int, slice_info: Dict[str, Any]):
         """Log del procesamiento de slice."""
         candidates = slice_info.get('candidates', 0)
         if candidates > 0:
             self.logger.info(f"{Colors.DETECTION}Slice {slice_idx}: {candidates} candidatos detectados{Colors.ENDC}")
     
-    # This function logs GPU information.
     def gpu_info(self, message: str, level: str = "INFO"):
         """Log de información GPU."""
         if level.upper() == "INFO":
@@ -210,7 +195,6 @@ class DRAFTSLogger:
         elif level.upper() == "DEBUG":
             self.logger.debug(f"{Colors.GPU} {message}{Colors.ENDC}")
     
-    # This function logs detailed file information.
     def debug_file_info(self, file_info: Dict[str, Any]):
         """Log de información detallada de archivo (solo en DEBUG)."""
         self.logger.debug(f"Información del archivo:")
@@ -219,7 +203,6 @@ class DRAFTSLogger:
         self.logger.debug(f"   - Frecuencia inicial: {file_info.get('freq_start', 0):.1f} MHz")
         self.logger.debug(f"   - Ancho de banda: {file_info.get('bandwidth', 0):.1f} MHz")
     
-    # This function logs slice configuration.
     def slice_config(self, config_info: Dict[str, Any]):
         """Log de configuración de slice."""
         self.logger.info(f"Configuración de slice:")
@@ -227,37 +210,31 @@ class DRAFTSLogger:
         self.logger.info(f"SLICE_LEN: {config_info.get('slice_len', 0)} muestras")
         self.logger.info(f"Duración real: {config_info.get('real_ms', 0):.1f} ms")
     
-    # This function logs slice progress.
     def slice_progress(self, current_slice: int, total_slices: int, chunk_idx: Optional[int] = None):
         """Log de progreso de slices."""
         percentage = (current_slice / total_slices) * 100 if total_slices > 0 else 0
         chunk_info = f" (chunk {chunk_idx:03d})" if chunk_idx is not None else ""
         self.logger.info(f"{Colors.PROCESSING} Progreso: slice {current_slice:03d}/{total_slices-1:03d} ({percentage:.1f}%){chunk_info}{Colors.ENDC}")
     
-    # This function logs detected candidates.
     def candidate_detected(self, dm: float, time: float, confidence: float, class_prob: float, is_burst: bool, snr_raw: float, snr_patch: float):
         """Log de candidato detectado."""
         burst_status = "BURST" if is_burst else "NO burst"
         self.logger.info(f"{Colors.DETECTION} Candidato encontrado: DM={dm:.1f} t={time:.3f}s conf={confidence:.2f} class={class_prob:.2f} → {burst_status}{Colors.ENDC}")
         self.logger.info(f"{Colors.OKCYAN} SNR Raw: {snr_raw:.2f}σ, SNR Patch: {snr_patch:.2f}σ{Colors.ENDC}")
     
-    # This function logs slice completion.
     def slice_completed(self, slice_idx: int, candidates: int, bursts: int, no_bursts: int):
         """Log de slice completado."""
         if candidates > 0:
             self.logger.info(f"{Colors.DETECTION} Slice {slice_idx:03d} completado: {candidates} candidatos ({bursts} bursts, {no_bursts} no bursts){Colors.ENDC}")
     
-    # This function logs chunk completion.
     def chunk_completed(self, chunk_idx: int, total_candidates: int, total_bursts: int, total_no_bursts: int):
         """Log de chunk completado."""
         self.logger.info(f"{Colors.PROCESSING} Chunk {chunk_idx:03d} completado: {total_candidates} candidatos totales ({total_bursts} bursts, {total_no_bursts} no bursts){Colors.ENDC}")
     
-    # This function logs band processing.
     def processing_band(self, band_name: str, slice_idx: int):
         """Log de procesamiento de banda."""
         self.logger.info(f"{Colors.PROCESSING} Procesando {band_name} (slice {slice_idx}){Colors.ENDC}")
     
-    # This function logs candidates per band.
     def band_candidates(self, band_name: str, candidate_count: int):
         """Log de candidatos por banda."""
         if candidate_count > 0:
@@ -265,19 +242,16 @@ class DRAFTSLogger:
         else:
             self.logger.debug(f"{Colors.OKCYAN} {band_name}: Sin candidatos detectados{Colors.ENDC}")
     
-    # This function logs waterfall creation.
     def creating_waterfall(self, waterfall_type: str, slice_idx: int, dm: Optional[float] = None):
         """Log de creación de waterfall."""
         dm_info = f" (DM={dm:.1f})" if dm is not None else ""
         self.logger.debug(f"{Colors.OKCYAN} Creando waterfall {waterfall_type} para slice {slice_idx}{dm_info}{Colors.ENDC}")
     
-    # This function logs plot generation.
     def generating_plots(self):
         """Log de generación de plots."""
         self.logger.debug(f"{Colors.OKCYAN} Generando plots compuestos y de detección{Colors.ENDC}")
 
 
-# This function sets up logging.
 def setup_logging(level: str = "INFO", log_file: Optional[Path] = None, 
                  use_colors: bool = True) -> DRAFTSLogger:
     """
@@ -294,7 +268,6 @@ def setup_logging(level: str = "INFO", log_file: Optional[Path] = None,
     return DRAFTSLogger("DRAFTS", level, log_file, use_colors)
 
 
-# This function retrieves a configured logger.
 def get_logger(name: str = "DRAFTS") -> logging.Logger:
     """Obtiene un logger configurado."""
     return logging.getLogger(name)
@@ -303,7 +276,6 @@ def get_logger(name: str = "DRAFTS") -> logging.Logger:
                       
 _global_logger: Optional[DRAFTSLogger] = None
 
-# This function retrieves the global logger.
 def get_global_logger() -> DRAFTSLogger:
     """Obtiene el logger global configurado."""
     global _global_logger
@@ -311,7 +283,6 @@ def get_global_logger() -> DRAFTSLogger:
         _global_logger = setup_logging()
     return _global_logger
 
-# This function sets the global logger.
 def set_global_logger(logger: DRAFTSLogger):
     """Establece el logger global."""
     global _global_logger

--- a/src/logging/pipeline_logging.py
+++ b/src/logging/pipeline_logging.py
@@ -16,7 +16,6 @@ from typing import Any, Callable, Dict, Optional
 from .logging_config import get_global_logger
 
 
-# This function logs streaming parameters.
 def log_streaming_parameters(effective_chunk_samples: int, overlap_raw: int,
                             total_samples: int, chunk_samples: int,
                             streaming_func: Callable, file_type: str) -> None:
@@ -37,7 +36,6 @@ def log_streaming_parameters(effective_chunk_samples: int, overlap_raw: int,
     logger.logger.debug(f"[DEBUG] DEBUG STREAMING: streaming_func={getattr(streaming_func, '__name__', str(streaming_func))}, file_type={file_type}")
 
 
-# This function logs block processing.
 def log_block_processing(actual_chunk_count: int, block_shape: tuple, block_dtype: str,
                          metadata: Dict[str, Any]) -> None:
     """
@@ -61,7 +59,6 @@ def log_block_processing(actual_chunk_count: int, block_shape: tuple, block_dtyp
     logger.logger.debug(f"[DEBUG] DEBUG BLOQUE {actual_chunk_count}: overlap_right={metadata.get('overlap_right', 'N/A')}")
 
 
-# This function logs processing summary.
 def log_processing_summary(actual_chunk_count: int, chunk_count: int,
                           cand_counter_total: int, n_bursts_total: int) -> None:
     """
@@ -79,7 +76,6 @@ def log_processing_summary(actual_chunk_count: int, chunk_count: int,
     logger.logger.debug(f"[DEBUG] DEBUG RESUMEN: archivo procesado completamente a través de streaming")
 
 
-# This function logs pipeline file processing.
 def log_pipeline_file_processing(fits_path_name: str, file_suffix: str,
                                 total_samples: int, chunk_samples: int) -> None:
     """
@@ -99,7 +95,6 @@ def log_pipeline_file_processing(fits_path_name: str, file_suffix: str,
     logger.logger.debug(f"[DEBUG] DEBUG PIPELINE: SIEMPRE llamando a _process_file_chunked (nunca a _process_file)")
 
 
-# This function logs pipeline file completion.
 def log_pipeline_file_completion(fits_path_name: str, results: Dict[str, Any]) -> None:
     """
     Registra la finalización del procesamiento de un archivo en el pipeline.

--- a/src/models/BinaryClass/binary_data.py
+++ b/src/models/BinaryClass/binary_data.py
@@ -14,7 +14,6 @@ from torch.utils.data import Dataset
 
 class BurstDataset(Dataset):
 
-    # This function initializes the burst dataset.
     def __init__(self, data, val=False):
         self.image = data.file_name.values
         self.label = data.label.values
@@ -26,11 +25,9 @@ class BurstDataset(Dataset):
             transforms.RandomHorizontalFlip(p=0.5)
         ])
 
-    # This function returns the dataset length.
     def __len__(self):
         return len(self.image)
 
-    # This function retrieves a dataset sample.
     def __getitem__(self, idx):
         X, y       = self.random_comb_data(idx)                   
         X          = torch.from_numpy(X[None, :, :].astype(np.float32))
@@ -39,7 +36,6 @@ class BurstDataset(Dataset):
             X      = self.trans(X)
         return X, y
 
-    # This function preprocesses data.
     def preprocess_data(self, data, mean_norm=True, exp_cut=5):
         data       = data.copy()
         if np.random.rand() > 0.5:
@@ -52,7 +48,6 @@ class BurstDataset(Dataset):
         data       = (data - np.min(data)) / (np.max(data) - np.min(data))
         return data
 
-    # This function loads a single data sample.
     def load_single_data(self, idx):
         data, label = np.load(self.image[idx]), self.label[idx]
         if np.abs(data.max() - data.min() - 1) < 1:
@@ -62,7 +57,6 @@ class BurstDataset(Dataset):
         data = self.preprocess_data(data, mean_norm=mean_norm, exp_cut=exp_cut)
         return data, label
 
-    # This function randomly combines training data.
     def random_comb_data(self, idx):
         comb_num = np.random.randint(1, 6)
         comb_idx = np.append([idx], np.random.choice(len(self.image), comb_num - 1, replace=False))
@@ -89,7 +83,6 @@ class BurstDataset(Dataset):
         labels = 1 if np.any(np.array([self.label[j] for j in comb_idx]) == 1) else 0
         return comb_data, labels
 
-    # This function adds noise.
     def add_noise(self, data):
         data_max, data_min   = data.max(), data.min()
             
@@ -175,7 +168,6 @@ class BurstDataset(Dataset):
         return data
 
 
-# This function prepares training and validation splits.
 def get_train_val(root_path='./Data/'):
 
     positive_path = root_path + 'True/'

--- a/src/models/BinaryClass/binary_model.py
+++ b/src/models/BinaryClass/binary_model.py
@@ -6,7 +6,6 @@ from torchvision import transforms
 
 
 if True:
-    # This function applies random resizing to inputs.
     def random_resize(inputs):
 
         h, w = np.random.randint(128, 513), np.random.randint(128, 513)
@@ -15,7 +14,6 @@ if True:
         return inputs
 
 if False:
-    # This function applies random resizing to inputs.
     def random_resize(inputs):
 
         random_seed = np.random.rand()
@@ -39,7 +37,6 @@ if False:
 
 class BinaryNet(torch.nn.Module):
 
-    # This function initializes the binary classification network.
     def __init__(self, model_name='resnet18', num_classes=2):
         super(BinaryNet, self).__init__()
         model_dict = {
@@ -53,7 +50,6 @@ class BinaryNet(torch.nn.Module):
         self.base_model.conv1 = torch.nn.Conv2d(1, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False)
         self.base_model.fc    = torch.nn.Linear(num_ch, num_classes)
 
-    # This function runs a forward pass for classification.
     def forward(self, x):
         x = self.base_model(x)               
         return x
@@ -61,12 +57,10 @@ class BinaryNet(torch.nn.Module):
 
 class SpatialPyramidPool2D(torch.nn.Module):
 
-    # This function initializes the spatial pyramid pooling module.
     def __init__(self, out_side):
         super(SpatialPyramidPool2D, self).__init__()
         self.out_side = out_side
 
-    # This function applies spatial pyramid pooling.
     def forward(self, x):
         out         = None
         for n in self.out_side:
@@ -80,7 +74,6 @@ class SpatialPyramidPool2D(torch.nn.Module):
 
 class SPPResNet(torch.nn.Module):
 
-    # This function initializes the SPP ResNet classifier.
     def __init__(self, model_name='resnet18', num_classes=2, pool_size=(1, 2, 6)):
 
         super().__init__()
@@ -98,7 +91,6 @@ class SPPResNet(torch.nn.Module):
         num_features    = num_ch * (pool_size[0]**2 + pool_size[1]**2 + pool_size[2]**2)
         self.classifier = torch.nn.Linear(num_features, num_classes)
 
-    # This function runs a forward pass with spatial pyramid pooling.
     def forward(self, x):
 
         x = self.base_model.conv1(x)

--- a/src/models/BinaryClass/binary_train.py
+++ b/src/models/BinaryClass/binary_train.py
@@ -19,7 +19,6 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
                          
 
 
-# This function plots scheduler.
 def plot_scheduler(epoches):
 
     model     = torchvision.models.resnet18()

--- a/src/models/ObjectDet/centernet_data.py
+++ b/src/models/ObjectDet/centernet_data.py
@@ -14,7 +14,6 @@ data_path   = './Data/'
 
 
 if False:
-    # This function draws gaussian.
     def draw_gaussian(heatmap, center, w_radius, h_radius, k=1):
 
         theta    = np.arctan2(h_radius, w_radius)
@@ -33,7 +32,6 @@ if False:
         return heatmap
 
 
-    # This function computes a 2D Gaussian kernel.
     def gaussian2D(shape, sx, theta):
 
                    
@@ -51,7 +49,6 @@ if False:
 
 
 if False:
-    # This function draws gaussian.
     def draw_gaussian(heatmap, center, w_radius, h_radius, k=1):
 
         radius   = np.min([w_radius, h_radius])
@@ -70,7 +67,6 @@ if False:
         return heatmap
 
 
-    # This function computes a 2D Gaussian kernel.
     def gaussian2D(shape, sigma=1):
 
         m, n = [(ss - 1.) / 2. for ss in shape]
@@ -83,7 +79,6 @@ if False:
 
 if True:
              
-    # This function draws gaussian.
     def draw_gaussian(heatmap, center, w_radius, h_radius):
 
         sigma    = np.clip(w_radius * h_radius // 2000, 2, 4)
@@ -111,7 +106,6 @@ if True:
         return heatmap
 
 
-# This function generates CenterNet training tensors.
 def make_data(target):
 
     output_shape = input_size // model_scale
@@ -143,13 +137,11 @@ def make_data(target):
 
 class Normalize(object):
 
-    # This function initializes normalization parameters.
     def __init__(self):
 
         self.mean = [0.485, 0.456, 0.406]
         self.std  = [0.229, 0.224, 0.225]
 
-    # This function normalizes an image tensor.
     def __call__(self, image):
 
         image  = image.astype(np.float32)
@@ -161,7 +153,6 @@ class Normalize(object):
 
 class BurstDataset(torch.utils.data.Dataset):
 
-    # This function initializes the burst dataset.
     def __init__(self, img_id, labels, val=False, transform=None):
 
         self.img_id = img_id
@@ -171,11 +162,9 @@ class BurstDataset(torch.utils.data.Dataset):
         self.normalize = Normalize()
         self.val = val
 
-    # This function returns the dataset length.
     def __len__(self):
         return len(self.img_id)
 
-    # This function retrieves a dataset sample.
     def __getitem__(self, idx):
 
         img, target = self.load_img(idx)       
@@ -185,7 +174,6 @@ class BurstDataset(torch.utils.data.Dataset):
 
         return img, targ_gt
 
-    # This function loads a processed image sample.
     def load_img(self, idx):
 
         if self.val:
@@ -197,7 +185,6 @@ class BurstDataset(torch.utils.data.Dataset):
 
         return img, target
 
-    # This function loads an image using the legacy pipeline.
     def load_img_old(self, idx):
 
         img, target      = self.load_raw_data(idx)
@@ -209,7 +196,6 @@ class BurstDataset(torch.utils.data.Dataset):
 
         return img, target
 
-    # This function loads raw data.
     def load_raw_data(self, idx):
 
         frb_path = self.img_id[idx].split('__')[0] + '.npy'
@@ -224,7 +210,6 @@ class BurstDataset(torch.utils.data.Dataset):
 
         return img, target
 
-    # This function downsamples image data and targets.
     def down_samp(self, img, target):
 
         img                  = np.mean(img.reshape(512, 2, 2048, 4), axis=(1, 3))
@@ -235,7 +220,6 @@ class BurstDataset(torch.utils.data.Dataset):
 
         return img, target
 
-    # This function randomly clips the data window.
     def random_clip(self, img, target):
 
                                    
@@ -263,7 +247,6 @@ class BurstDataset(torch.utils.data.Dataset):
         img                  = cv2.resize(img, (input_size, input_size))
         return img, target
 
-    # This function randomly combines multiple samples.
     def random_comb(self, idx):
 
         comb_num = np.random.randint(1, 6)
@@ -325,7 +308,6 @@ class BurstDataset(torch.utils.data.Dataset):
 
         return comb_data, targ_data
 
-    # This function renders a color image representation.
     def render_color(self, img):
 
         img = np.clip(img, *np.percentile(img, (0.1, 99.9)))

--- a/src/models/ObjectDet/centernet_model.py
+++ b/src/models/ObjectDet/centernet_model.py
@@ -7,7 +7,6 @@ import torch.nn.functional as F
 
 class double_conv(nn.Module):
 
-    # This function initializes the double convolution block.
     def __init__(self, in_ch, out_ch):
         super(double_conv, self).__init__()
 
@@ -20,7 +19,6 @@ class double_conv(nn.Module):
             nn.ReLU(inplace=True)
         )
 
-    # This function applies the double convolution block.
     def forward(self, x):
         x = self.conv(x)
         return x
@@ -28,7 +26,6 @@ class double_conv(nn.Module):
 
 class up(nn.Module):
 
-    # This function initializes the upsampling block.
     def __init__(self, in_ch, out_ch, bilinear=True):
         super(up, self).__init__()
 
@@ -38,7 +35,6 @@ class up(nn.Module):
             self.up = nn.ConvTranspose2d(in_ch // 2, in_ch // 2, 2, stride=2)
         self.conv   = double_conv(in_ch, out_ch)
 
-    # This function upsamples and merges feature maps.
     def forward(self, x1, x2=None):
 
         x1        = self.up(x1)
@@ -56,7 +52,6 @@ class up(nn.Module):
 
 class centernet(nn.Module):
 
-    # This function initializes the CenterNet backbone.
     def __init__(self, n_classes=1, model_name='resnet18'):
         super(centernet, self).__init__()
 
@@ -77,7 +72,6 @@ class centernet(nn.Module):
         self.wh_head     = nn.Conv2d(256, 2, 1)
         self.offset_head = nn.Conv2d(256, 2, 1)
 
-    # This function runs a forward pass through the model.
     def forward(self, x):
 
         x      = self.base_model(x)
@@ -91,7 +85,6 @@ class centernet(nn.Module):
         return hm, wh, offset
 
 
-# This function computes the focal loss.
 def focal_loss(pred, target):
 
     pos_inds    = target.eq(1).float()
@@ -113,7 +106,6 @@ def focal_loss(pred, target):
     return loss
 
 
-# This function computes the L1 regression loss.
 def reg_l1_loss(pred, target, mask):
 
     pred = pred.permute(0, 2, 3, 1)
@@ -126,7 +118,6 @@ def reg_l1_loss(pred, target, mask):
     return loss
 
 
-# This function computes the CenterNet loss components.
 def centerloss(pred, targ):
 
     hm, wh, offset = pred[:, 0], pred[:, 1:3], pred[:, 3:]

--- a/src/models/ObjectDet/centernet_train.py
+++ b/src/models/ObjectDet/centernet_train.py
@@ -18,7 +18,6 @@ from centernet_utils import get_res, denormalize
 from sklearn.model_selection import train_test_split
 
 
-# This function loads train cat.
 def load_train_cat(train_path):
 
     data              = pd.read_csv(train_path)

--- a/src/models/ObjectDet/centernet_utils.py
+++ b/src/models/ObjectDet/centernet_utils.py
@@ -6,7 +6,6 @@ from torch import nn
 from torchvision.ops import nms
 
 
-# This function denormalizes.
 def denormalize(img, mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]):
 
     img *= std
@@ -16,7 +15,6 @@ def denormalize(img, mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]):
     return img
 
 
-# This function pools nms.
 def pool_nms(heat, kernel=3):
 
     pad  = (kernel - 1) // 2
@@ -26,7 +24,6 @@ def pool_nms(heat, kernel=3):
     return heat * keep
 
 
-# This function decodes bbox.
 def decode_bbox(pred_hms, pred_whs, pred_offsets, confidence, cuda):
                                                                                
                                     
@@ -98,7 +95,6 @@ def decode_bbox(pred_hms, pred_whs, pred_offsets, confidence, cuda):
     return detects
 
 
-# This function postprocesses.
 def postprocess(prediction, need_nms, input_shape, nms_iou=0.4):
     output = [None for _ in range(len(prediction))]
 
@@ -141,7 +137,6 @@ def postprocess(prediction, need_nms, input_shape, nms_iou=0.4):
     return output
 
 
-# This function extracts detection results from model outputs.
 def get_res(hm, wh, offset, confidence):
 
     outputs = decode_bbox(hm, wh, offset, confidence, cuda=True)

--- a/src/output/candidate_manager.py
+++ b/src/output/candidate_manager.py
@@ -35,7 +35,6 @@ CANDIDATE_HEADER = [
 ]
 
 
-# This function ensures CSV header.
 def ensure_csv_header(csv_path: Path) -> None:
     """Create csv_path with the standard candidate header if needed."""
     csv_path.parent.mkdir(parents=True, exist_ok=True)
@@ -50,7 +49,6 @@ def ensure_csv_header(csv_path: Path) -> None:
         raise
 
 
-# This function appends candidate.
 def append_candidate(csv_path: Path, candidate_row: list) -> None:
     """Append a candidate row to the CSV file."""
     with csv_path.open("a", newline="") as f_csv:
@@ -76,7 +74,6 @@ class Candidate:
     patch_file: str | None = None
     width_ms: float | None = None
 
-    # This function converts a candidate to a CSV row.
     def to_row(self) -> List:
         """Convert candidate to CSV row format."""
         row = [

--- a/src/output/summary_manager.py
+++ b/src/output/summary_manager.py
@@ -14,7 +14,6 @@ from ..config import config
               
 logger = logging.getLogger(__name__)
 
-# This function writes summary with timestamp.
 def _write_summary_with_timestamp(summary: dict, save_path: Path, preserve_history: bool = True) -> None:
     """
     Write summary with timestamp and optionally preserve historical summaries.
@@ -97,7 +96,6 @@ def _write_summary_with_timestamp(summary: dict, save_path: Path, preserve_histo
         logger.info("Resumen con timestamp escrito en %s", timestamped_path)
 
 
-# This function loads or creates summary.
 def _load_or_create_summary(save_path: Path) -> dict:
     """Load existing summary.json or create a new one."""
     summary_path = save_path / "summary.json"
@@ -141,7 +139,6 @@ def _load_or_create_summary(save_path: Path) -> dict:
     }
 
 
-# This function loads or creates master summary.
 def _load_or_create_master_summary(master_path: Path) -> dict:
     """Load existing master summary or create a new one."""
     if master_path.exists():
@@ -166,7 +163,6 @@ def _load_or_create_master_summary(master_path: Path) -> dict:
     }
 
 
-# This function updates summary with file debug.
 def _update_summary_with_file_debug(
     save_path: Path, filename: str, debug_info: dict
 ) -> None:
@@ -191,7 +187,6 @@ def _update_summary_with_file_debug(
         logger.info(f"Debug info guardada para {filename} en {summary_path}")
 
 
-# This function updates summary with results.
 def _update_summary_with_results(
     save_path: Path, filename: str, results_info: dict
 ) -> None:

--- a/src/preprocessing/chunk_planner.py
+++ b/src/preprocessing/chunk_planner.py
@@ -20,7 +20,6 @@ class SlicePlan:
     duration_ms: float
 
 
-# This function plans slices for chunk.
 def plan_slices_for_chunk(
     num_samples_decimated: int,
     target_duration_ms: float,

--- a/src/preprocessing/data_downsampler.py
+++ b/src/preprocessing/data_downsampler.py
@@ -10,7 +10,6 @@ import numpy as np
 from ..config import config
 
 
-# This function downsamples data.
 def downsample_data(data: np.ndarray) -> np.ndarray:
     """Down-sample time-frequency data usando las tasas de :mod:`config`.
 

--- a/src/preprocessing/dedispersion.py
+++ b/src/preprocessing/dedispersion.py
@@ -23,7 +23,6 @@ except Exception:
 logger = logging.getLogger(__name__)
 
 
-# This function performs GPU-based dedispersion.
 def _de_disp_gpu(dm_time, data, freq, index, dm_values, mid_channel):
     x, y = cuda.grid(2)
     if x < dm_time.shape[1] and y < dm_time.shape[2]:
@@ -61,7 +60,6 @@ def _de_disp_gpu(dm_time, data, freq, index, dm_values, mid_channel):
         dm_time[2, x, y] = dm_time[0, x, y] - mid_val
 
 
-# This function performs CPU-based DM-time accumulation.
 def _d_dm_time_cpu(
     data: np.ndarray,
     height: int,
@@ -132,7 +130,6 @@ def _d_dm_time_cpu(
     return out
 
 
-# This function computes the DM-time cube with GPU acceleration.
 def d_dm_time_g(data: np.ndarray, height: int, width: int, chunk_size: int = 128, dm_min: float = None, dm_max: float = None) -> np.ndarray:
     result = np.zeros((3, height, width), dtype=np.float32)
     
@@ -207,7 +204,6 @@ def d_dm_time_g(data: np.ndarray, height: int, width: int, chunk_size: int = 128
         return _d_dm_time_cpu(data, height, width, dm_min, dm_max, freq_values)
 
 
-# This function performs Torch GPU dedispersion.
 def _d_dm_time_torch_gpu(
     data_np: np.ndarray,
     height: int,
@@ -279,7 +275,6 @@ def _d_dm_time_torch_gpu(
     result = torch.stack([out0, out1, out2], dim=0).detach().cpu().numpy().astype(np.float32)
     return result
 
-# This function dedisperses patch.
 def dedisperse_patch(
     data: np.ndarray,
     freq_down: np.ndarray,
@@ -316,7 +311,6 @@ def dedisperse_patch(
         patch[:, idx] = segment[delays[idx] : delays[idx] + patch_len, idx]
     return patch, start
 
-# This function dedisperses block.
 def dedisperse_block(
     data: np.ndarray,
     freq_down: np.ndarray,

--- a/src/preprocessing/dm_candidate_extractor.py
+++ b/src/preprocessing/dm_candidate_extractor.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from ..config import config
 
 
-# This function extracts candidate DM.
 def extract_candidate_dm(px: float, py: float, slice_len: int) -> tuple[float, float, int]:
     dm_range = config.DM_max - config.DM_min + 1
     scale_dm = dm_range / 512.0

--- a/src/preprocessing/slice_len_calculator.py
+++ b/src/preprocessing/slice_len_calculator.py
@@ -16,7 +16,6 @@ from ..config import config
 logger = logging.getLogger(__name__)
 
 
-# This function calculates slice length from duration.
 def calculate_slice_len_from_duration() -> Tuple[int, float]:
     """
     Calcula SLICE_LEN dinámicamente basado en SLICE_DURATION_MS y metadatos del archivo.
@@ -57,7 +56,6 @@ def calculate_slice_len_from_duration() -> Tuple[int, float]:
     return slice_len, real_duration_ms
 
 
-# This function calculates optimal chunk size.
 def calculate_optimal_chunk_size(slice_len: Optional[int] = None) -> int:
     """Determina cuántas muestras puede contener un chunk.
 
@@ -108,7 +106,6 @@ def calculate_optimal_chunk_size(slice_len: Optional[int] = None) -> int:
     return chunk_samples
 
 
-# This function gets processing parameters.
 def get_processing_parameters() -> dict:
     """Calcula automáticamente todos los parámetros de chunking y slicing.
 
@@ -273,7 +270,6 @@ def get_processing_parameters() -> dict:
     return parameters
 
 
-# This function updates slice length dynamic.
 def update_slice_len_dynamic():
     """
     Actualiza config.SLICE_LEN basado en SLICE_DURATION_MS.
@@ -297,7 +293,6 @@ def update_slice_len_dynamic():
     return slice_len, real_duration_ms
 
 
-# This function validates processing parameters.
 def validate_processing_parameters(parameters: dict) -> bool:
     """
     Valida que los parámetros calculados sean razonables.

--- a/src/scripts/absolute_segment_plots.py
+++ b/src/scripts/absolute_segment_plots.py
@@ -23,7 +23,6 @@ from ..visualization.plot_waterfall_dispersed import save_waterfall_dispersed_pl
 from ..visualization.plot_waterfall_dedispersed import save_waterfall_dedispersed_plot
 
 
-# This function infers file type.
 def _infer_file_type(path: Path) -> str:
     suffix = path.suffix.lower()
     if suffix == ".fits":
@@ -33,12 +32,10 @@ def _infer_file_type(path: Path) -> str:
     raise ValueError(f"Tipo de archivo no soportado: {suffix}")
 
 
-# This function ensures that the output directory exists.
 def _ensure_dir(p: Path) -> None:
     p.mkdir(parents=True, exist_ok=True)
 
 
-# This function computes indices.
 def _compute_indices(start_sec: float, duration_sec: float) -> tuple[int, int, float]:
     """Convierte tiempo absoluto a índices en dominio decimado del pipeline.
 
@@ -51,7 +48,6 @@ def _compute_indices(start_sec: float, duration_sec: float) -> tuple[int, int, f
     return start_idx, end_idx, dt_ds
 
 
-# This function computes the downsampled frequency grid.
 def _compute_freq_down() -> np.ndarray:
     """Devuelve el eje de frecuencias decimado exactamente como el pipeline (promedio por grupos)."""
     freq = np.asarray(config.FREQ).reshape(-1)
@@ -66,7 +62,6 @@ def _compute_freq_down() -> np.ndarray:
     return freq_ds
 
 
-# This function runs single segment.
 def run_single_segment(
     filename: Path,
     start: float,
@@ -174,7 +169,6 @@ def run_single_segment(
     )
 
 
-# This function runs the absolute segment plotting script.
 def main():
     parser = argparse.ArgumentParser(
         description=(

--- a/src/scripts/fits_header_analyzer.py
+++ b/src/scripts/fits_header_analyzer.py
@@ -119,7 +119,6 @@ PROCESSING_HEADERS = [
                                   
                                                                                
 
-# This function analyzes primary header.
 def analyze_primary_header(header: fits.Header) -> Dict[str, Any]:
     """
     Analiza el header primario del archivo FITS.
@@ -218,7 +217,6 @@ def analyze_primary_header(header: fits.Header) -> Dict[str, Any]:
 
     return analysis
 
-# This function analyzes extension headers.
 def analyze_extension_headers(hdul: fits.HDUList) -> List[Dict[str, Any]]:
     """
     Analiza los headers de todas las extensiones del archivo FITS.
@@ -263,7 +261,6 @@ def analyze_extension_headers(hdul: fits.HDUList) -> List[Dict[str, Any]]:
 
     return extensions_analysis
 
-# This function analyzes file structure.
 def analyze_file_structure(filepath: Path) -> Dict[str, Any]:
     """
     Analiza la estructura general del archivo FITS.
@@ -324,7 +321,6 @@ def analyze_file_structure(filepath: Path) -> Dict[str, Any]:
 
     return structure_info
 
-# This function analyzes observational metadata.
 def analyze_observational_metadata(header: fits.Header) -> Dict[str, Any]:
     """
     Analiza metadatos astronómicos y observacionales detalladamente.
@@ -408,7 +404,6 @@ def analyze_observational_metadata(header: fits.Header) -> Dict[str, Any]:
                       
                                                                                
 
-# This function calculates data size.
 def _calculate_data_size(hdu: fits.HDU) -> float:
     """Calcula el tamaño de los datos en MB."""
     if hdu.data is None:
@@ -426,7 +421,6 @@ def _calculate_data_size(hdu: fits.HDU) -> float:
     except:
         return 0.0
 
-# This function extracts extension specific headers.
 def _extract_extension_specific_headers(header: fits.Header, hdu: fits.HDU) -> Dict[str, Any]:
     """Extrae headers específicos según el tipo de extensión."""
     specific_headers = {}
@@ -457,7 +451,6 @@ def _extract_extension_specific_headers(header: fits.Header, hdu: fits.HDU) -> D
 
     return specific_headers
 
-# This function validates header integrity.
 def _validate_header_integrity(header: fits.Header) -> List[str]:
     """Valida la integridad del header y retorna warnings."""
     warnings = []
@@ -483,7 +476,6 @@ def _validate_header_integrity(header: fits.Header) -> List[str]:
 
     return warnings
 
-# This function checks header errors.
 def _check_header_errors(header: fits.Header) -> List[str]:
     """Verifica errores críticos en el header."""
     errors = []
@@ -496,7 +488,6 @@ def _check_header_errors(header: fits.Header) -> List[str]:
 
     return errors
 
-# This function validates extension integrity.
 def _validate_extension_integrity(hdu: fits.HDU) -> List[str]:
     """Valida la integridad de una extensión."""
     warnings = []
@@ -511,7 +502,6 @@ def _validate_extension_integrity(hdu: fits.HDU) -> List[str]:
 
     return warnings
 
-# This function checks extension errors.
 def _check_extension_errors(hdu: fits.HDU) -> List[str]:
     """Verifica errores en una extensión."""
     errors = []
@@ -523,7 +513,6 @@ def _check_extension_errors(hdu: fits.HDU) -> List[str]:
 
     return errors
 
-# This function calculates derived parameters.
 def _calculate_derived_parameters(header: fits.Header) -> Dict[str, Any]:
     """Calcula parámetros derivados de los headers."""
     derived = {}
@@ -565,7 +554,6 @@ def _calculate_derived_parameters(header: fits.Header) -> Dict[str, Any]:
                                      
                                                                                
 
-# This function prints analysis report.
 def print_analysis_report(filepath: Path, analysis: Dict[str, Any]) -> None:
     """
     Imprime un reporte completo del análisis del archivo FITS.
@@ -661,7 +649,6 @@ def print_analysis_report(filepath: Path, analysis: Dict[str, Any]) -> None:
         for error in analysis['primary']['errors']:
             print(f"  • {error}")
 
-# This function prints summary report.
 def print_summary_report(files_analyzed: List[Dict[str, Any]]) -> None:
     """
     Imprime un reporte resumen de todos los archivos analizados.
@@ -709,7 +696,6 @@ def print_summary_report(files_analyzed: List[Dict[str, Any]]) -> None:
                        
                                                                                
 
-# This function analyzes FITS file.
 def analyze_fits_file(filepath: Path) -> Dict[str, Any]:
     """
     Función principal para analizar un archivo FITS completo.
@@ -763,7 +749,6 @@ def analyze_fits_file(filepath: Path) -> Dict[str, Any]:
 
     return analysis
 
-# This function runs the FITS header analyzer CLI.
 def main():
     """Función principal del script."""
     parser = argparse.ArgumentParser(

--- a/src/scripts/test_slicing_alignment.py
+++ b/src/scripts/test_slicing_alignment.py
@@ -25,13 +25,11 @@ from src.input.filterbank_handler import get_obparams_fil, stream_fil
 from src.config import config
 
 
-# This function asserts approximate equality.
 def _assert_close(a: float, b: float, tol: float, what: str) -> None:
     if not (abs(a - b) <= tol):
         raise AssertionError(f"{what}: esperado {b}, obtenido {a}, tol={tol}")
 
 
-# This function tests PSRFITS slicing.
 def test_psrfits_slicing(fits_path: str, slice_sec: float) -> None:
                                    
     get_obparams(fits_path)
@@ -97,7 +95,6 @@ def test_psrfits_slicing(fits_path: str, slice_sec: float) -> None:
     print(f"[PSRFITS] OK: {num_chunks} chunks, total_emitted={total_emitted}/{nsamples}")
 
 
-# This function tests filterbank slicing.
 def test_filterbank_slicing(fil_path: str, slice_sec: float) -> None:
     get_obparams_fil(fil_path)
     tsamp = float(config.TIME_RESO)
@@ -144,7 +141,6 @@ def test_filterbank_slicing(fil_path: str, slice_sec: float) -> None:
     print(f"[FIL] OK: {num_chunks} chunks, total_emitted={total_emitted}/{nsamples}")
 
 
-# This function runs the slicing alignment test harness.
 def main() -> None:
     parser = argparse.ArgumentParser(description="Test de slicing para PSRFITS y Filterbank")
     parser.add_argument("--fits", type=str, default=None, help="Ruta a archivo .fits (PSRFITS)")

--- a/src/visualization/plot_composite.py
+++ b/src/visualization/plot_composite.py
@@ -23,7 +23,6 @@ from .visualization_ranges import get_dynamic_dm_range_for_candidate
 logger = logging.getLogger(__name__)
 
 
-# This function calculates dynamic DM range.
 def _calculate_dynamic_dm_range(
     top_boxes: Iterable | None,
     slice_len: int,
@@ -75,7 +74,6 @@ def _calculate_dynamic_dm_range(
         return float(dm_min), float(dm_max)
 
 
-# This function gets band frequency range.
 def get_band_frequency_range(band_idx: int) -> Tuple[float, float]:
     """Get the frequency range (min, max) for a specific band."""
     freq_ds = np.mean(
@@ -96,14 +94,12 @@ def get_band_frequency_range(band_idx: int) -> Tuple[float, float]:
         return freq_ds.min(), freq_ds.max()
 
 
-# This function gets band name with frequency range.
 def get_band_name_with_freq_range(band_idx: int, band_name: str) -> str:
     """Get band name with frequency range information."""
     freq_min, freq_max = get_band_frequency_range(band_idx)
     return f"{band_name} ({freq_min:.0f}-{freq_max:.0f} MHz)"
 
 
-# This function creates composite plot.
 def create_composite_plot(
     waterfall_block: np.ndarray,
     dedispersed_block: np.ndarray,
@@ -656,7 +652,6 @@ def create_composite_plot(
     return fig
 
 
-# This function saves composite plot.
 def save_composite_plot(
     waterfall_block: np.ndarray,
     dedispersed_block: np.ndarray,

--- a/src/visualization/plot_dm_time.py
+++ b/src/visualization/plot_dm_time.py
@@ -21,7 +21,6 @@ from .visualization_ranges import get_dynamic_dm_range_for_candidate
 logger = logging.getLogger(__name__)
 
 
-# This function calculates dynamic DM range.
 def _calculate_dynamic_dm_range(
     top_boxes: Iterable | None,
     slice_len: int,
@@ -73,7 +72,6 @@ def _calculate_dynamic_dm_range(
         return float(dm_min), float(dm_max)
 
 
-# This function gets band frequency range.
 def get_band_frequency_range(band_idx: int) -> Tuple[float, float]:
     """Get the frequency range (min, max) for a specific band."""
     freq_ds = np.mean(
@@ -94,14 +92,12 @@ def get_band_frequency_range(band_idx: int) -> Tuple[float, float]:
         return freq_ds.min(), freq_ds.max()
 
 
-# This function gets band name with frequency range.
 def get_band_name_with_freq_range(band_idx: int, band_name: str) -> str:
     """Get band name with frequency range information."""
     freq_min, freq_max = get_band_frequency_range(band_idx)
     return f"{band_name} ({freq_min:.0f}-{freq_max:.0f} MHz)"
 
 
-# This function creates DM time plot.
 def create_dm_time_plot(
     img_rgb: np.ndarray,
     top_conf: Iterable,
@@ -286,7 +282,6 @@ def create_dm_time_plot(
     return fig
 
 
-# This function saves DM time plot.
 def save_dm_time_plot(
     img_rgb: np.ndarray,
     top_conf: Iterable,

--- a/src/visualization/plot_individual_components.py
+++ b/src/visualization/plot_individual_components.py
@@ -18,7 +18,6 @@ from .plot_patches import save_patches_plot
 logger = logging.getLogger(__name__)
 
 
-# This function generates individual plots.
 def generate_individual_plots(
     waterfall_block,
     dedispersed_block,
@@ -170,7 +169,6 @@ def generate_individual_plots(
         raise
 
 
-# This function generates individual plots from composite params.
 def generate_individual_plots_from_composite_params(
     composite_params: dict,
     base_out_path: Path,

--- a/src/visualization/plot_patches.py
+++ b/src/visualization/plot_patches.py
@@ -21,7 +21,6 @@ from ..config import config
 logger = logging.getLogger(__name__)
 
 
-# This function gets band frequency range.
 def get_band_frequency_range(band_idx: int) -> Tuple[float, float]:
     """Get the frequency range (min, max) for a specific band."""
     freq_ds = np.mean(
@@ -42,14 +41,12 @@ def get_band_frequency_range(band_idx: int) -> Tuple[float, float]:
         return freq_ds.min(), freq_ds.max()
 
 
-# This function gets band name with frequency range.
 def get_band_name_with_freq_range(band_idx: int, band_name: str) -> str:
     """Get band name with frequency range information."""
     freq_min, freq_max = get_band_frequency_range(band_idx)
     return f"{band_name} ({freq_min:.0f}-{freq_max:.0f} MHz)"
 
 
-# This function creates patches plot.
 def create_patches_plot(
     patch_img: np.ndarray,
     patch_start: float,
@@ -236,7 +233,6 @@ def create_patches_plot(
     return fig
 
 
-# This function saves patches plot.
 def save_patches_plot(
     patch_img: np.ndarray,
     patch_start: float,

--- a/src/visualization/plot_waterfall_dedispersed.py
+++ b/src/visualization/plot_waterfall_dedispersed.py
@@ -22,7 +22,6 @@ from ..preprocessing.dm_candidate_extractor import extract_candidate_dm
 logger = logging.getLogger(__name__)
 
 
-# This function gets band frequency range.
 def get_band_frequency_range(band_idx: int) -> Tuple[float, float]:
     """Get the frequency range (min, max) for a specific band."""
     freq_ds = np.mean(
@@ -43,14 +42,12 @@ def get_band_frequency_range(band_idx: int) -> Tuple[float, float]:
         return freq_ds.min(), freq_ds.max()
 
 
-# This function gets band name with frequency range.
 def get_band_name_with_freq_range(band_idx: int, band_name: str) -> str:
     """Get band name with frequency range information."""
     freq_min, freq_max = get_band_frequency_range(band_idx)
     return f"{band_name} ({freq_min:.0f}-{freq_max:.0f} MHz)"
 
 
-# This function creates waterfall dedispersed plot.
 def create_waterfall_dedispersed_plot(
     dedispersed_block: np.ndarray,
     waterfall_block: np.ndarray,
@@ -305,7 +302,6 @@ def create_waterfall_dedispersed_plot(
     return fig
 
 
-# This function saves waterfall dedispersed plot.
 def save_waterfall_dedispersed_plot(
     dedispersed_block: np.ndarray,
     waterfall_block: np.ndarray,

--- a/src/visualization/plot_waterfall_dispersed.py
+++ b/src/visualization/plot_waterfall_dispersed.py
@@ -21,7 +21,6 @@ from ..config import config
 logger = logging.getLogger(__name__)
 
 
-# This function calculates undispersed burst time.
 def calculate_undispersed_burst_time(
     observed_time: float, 
     dm: float, 
@@ -77,7 +76,6 @@ def calculate_undispersed_burst_time(
     return undispersed_time
 
 
-# This function gets band frequency range.
 def get_band_frequency_range(band_idx: int) -> Tuple[float, float]:
     """Get the frequency range (min, max) for a specific band."""
     freq_ds = np.mean(
@@ -98,14 +96,12 @@ def get_band_frequency_range(band_idx: int) -> Tuple[float, float]:
         return freq_ds.min(), freq_ds.max()
 
 
-# This function gets band name with frequency range.
 def get_band_name_with_freq_range(band_idx: int, band_name: str) -> str:
     """Get band name with frequency range information."""
     freq_min, freq_max = get_band_frequency_range(band_idx)
     return f"{band_name} ({freq_min:.0f}-{freq_max:.0f} MHz)"
 
 
-# This function creates waterfall dispersed plot.
 def create_waterfall_dispersed_plot(
     waterfall_block: np.ndarray,
     slice_idx: int,
@@ -354,7 +350,6 @@ def create_waterfall_dispersed_plot(
     return fig
 
 
-# This function saves waterfall dispersed plot.
 def save_waterfall_dispersed_plot(
     waterfall_block: np.ndarray,
     out_path: Path,

--- a/src/visualization/visualization_ranges.py
+++ b/src/visualization/visualization_ranges.py
@@ -11,11 +11,9 @@ logger = logging.getLogger(__name__)
 class DynamicDMRangeCalculator:
     """Calculadora de rangos DM dinámicos para visualización óptima."""
     
-    # This function initializes the range calculator.
     def __init__(self):
         self.dm_ranges_cache = {}
         
-    # This function calculates optimal DM range.
     def calculate_optimal_dm_range(
         self,
         dm_optimal: float,
@@ -104,7 +102,6 @@ class DynamicDMRangeCalculator:
         
         return dm_plot_min, dm_plot_max, calculation_details
     
-    # This function analyzes dispersion for range.
     def _analyze_dispersion_for_range(
         self, 
         dm_min: float, 
@@ -133,7 +130,6 @@ class DynamicDMRangeCalculator:
             'temporal_resolution_factor': disp_samples_range / 512                      
         }
     
-    # This function calculates the DM range for multiple candidates.
     def calculate_multiple_candidates_range(
         self,
         dm_candidates: List[float],
@@ -201,7 +197,6 @@ class DynamicDMRangeCalculator:
         
         return dm_plot_min, dm_plot_max, calculation_details
     
-    # This function calculates adaptive DM range.
     def calculate_adaptive_dm_range(
         self,
         dm_optimal: float,
@@ -253,7 +248,6 @@ class DynamicDMRangeCalculator:
         
         return dm_plot_min, dm_plot_max, details
     
-    # This function gets DM range for visualization.
     def get_dm_range_for_visualization(
         self,
         visualization_type: str,
@@ -332,7 +326,6 @@ class DynamicDMRangeCalculator:
                                  
 dm_range_calculator = DynamicDMRangeCalculator()
 
-# This function gets dynamic DM range for candidate.
 def get_dynamic_dm_range_for_candidate(
     dm_optimal: float,
     config_module,
@@ -389,7 +382,6 @@ def get_dynamic_dm_range_for_candidate(
     
     return dm_plot_min, dm_plot_max
 
-# This function calculates the DM range for multiple candidates.
 def get_dynamic_dm_range_for_multiple_candidates(
     dm_candidates: List[float],
     config_module,

--- a/src/visualization/visualization_unified.py
+++ b/src/visualization/visualization_unified.py
@@ -33,7 +33,6 @@ if "mako" not in plt.colormaps():
         cmap=ListedColormap(sns.color_palette("mako", as_cmap=True)(np.linspace(0, 1, 256)))
     )
 
-# This function calculates dynamic DM range.
 def _calculate_dynamic_dm_range(
     top_boxes: Iterable | None,
     slice_len: int,
@@ -85,7 +84,6 @@ def _calculate_dynamic_dm_range(
         return float(dm_min), float(dm_max)
 
 
-# This function preprocesses img.
 def preprocess_img(img: np.ndarray) -> np.ndarray:
     img = (img - img.min()) / np.ptp(img)
     img = (img - img.mean()) / img.std()
@@ -98,7 +96,6 @@ def preprocess_img(img: np.ndarray) -> np.ndarray:
     return img.transpose(2, 0, 1)
 
 
-# This function postprocesses img.
 def postprocess_img(img_tensor: np.ndarray) -> np.ndarray:
     img = img_tensor.transpose(1, 2, 0)
     img *= [0.229, 0.224, 0.225]
@@ -106,7 +103,6 @@ def postprocess_img(img_tensor: np.ndarray) -> np.ndarray:
     img = (img * 255).astype(np.uint8)
     return cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
-# This function saves all plots.
 def save_all_plots(
     waterfall_block,
     dedisp_block,
@@ -176,7 +172,6 @@ def save_all_plots(
         logger.info(f"Plot composite generado en: {comp_path}")
         logger.info(f"Plots individuales generados automáticamente en: {comp_path.parent}/individual_plots/")
 
-# This function gets band frequency range.
 def get_band_frequency_range(band_idx: int) -> Tuple[float, float]:
     freq_ds = np.mean(
         config.FREQ.reshape(config.FREQ_RESO // config.DOWN_FREQ_RATE, config.DOWN_FREQ_RATE),
@@ -196,12 +191,10 @@ def get_band_frequency_range(band_idx: int) -> Tuple[float, float]:
         return freq_ds.min(), freq_ds.max()
 
 
-# This function gets band name with frequency range.
 def get_band_name_with_freq_range(band_idx: int, band_name: str) -> str:
     freq_min, freq_max = get_band_frequency_range(band_idx)
     return f"{band_name} ({freq_min:.0f}-{freq_max:.0f} MHz)"
 
-# This function saves slice summary.
 def save_slice_summary(
     waterfall_block: np.ndarray,
     dedispersed_block: np.ndarray,


### PR DESCRIPTION
## Summary
- translate pipeline-facing docstrings and inline documentation to English and remove redundant `# This function` comments across the pipeline modules
- simplify pipeline configuration helpers by dropping unused functions and clarifying parameter utilities
- clean user configuration comments and update logging/data-loader utilities to use consistent English messaging

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c98e2a4bc883229606bcbff468d9b2