### PR TITLE
Refine pipeline logging and replace prints with structured logs

### DIFF
--- a/src/input/filterbank_handler.py
+++ b/src/input/filterbank_handler.py
@@ -208,16 +208,16 @@ def load_fil_file(file_name: str) -> np.ndarray:
     
                                               
     if config.DEBUG_FREQUENCY_ORDER:
-        logger.debug(f" DATOS FIL] Archivo: {file_name}")
-        logger.debug(f" DATOS FIL] Shape de datos: {data_array.shape}")
-        logger.debug(f" DATOS FIL] Dimensiones: (tiempo={data_array.shape[0]}, pol={data_array.shape[1]}, freq={data_array.shape[2]})")
-        logger.debug(f" DATOS FIL] Tipo de datos: {data_array.dtype}")
-        logger.debug(f" DATOS FIL] Tamaño en memoria: {data_array.nbytes / (1024**3):.2f} GB")
-        logger.debug(f" DATOS FIL] Reversión aplicada: {global_vars.DATA_NEEDS_REVERSAL}")
-        logger.debug(f" DATOS FIL] Rango de valores: [{data_array.min():.3f}, {data_array.max():.3f}]")
-        logger.debug(f" DATOS FIL] Valor medio: {data_array.mean():.3f}")
-        logger.debug(f" DATOS FIL] Desviación estándar: {data_array.std():.3f}")
-        logger.debug(" DATOS FIL] " + "="*50)
+        logger.debug(f"[DEBUG DATOS FIL] Archivo: {file_name}")
+        logger.debug(f"[DEBUG DATOS FIL] Shape de datos: {data_array.shape}")
+        logger.debug(f"[DEBUG DATOS FIL] Dimensiones: (tiempo={data_array.shape[0]}, pol={data_array.shape[1]}, freq={data_array.shape[2]})")
+        logger.debug(f"[DEBUG DATOS FIL] Tipo de datos: {data_array.dtype}")
+        logger.debug(f"[DEBUG DATOS FIL] Tamaño en memoria: {data_array.nbytes / (1024**3):.2f} GB")
+        logger.debug(f"[DEBUG DATOS FIL] Reversión aplicada: {global_vars.DATA_NEEDS_REVERSAL}")
+        logger.debug(f"[DEBUG DATOS FIL] Rango de valores: [{data_array.min():.3f}, {data_array.max():.3f}]")
+        logger.debug(f"[DEBUG DATOS FIL] Valor medio: {data_array.mean():.3f}")
+        logger.debug(f"[DEBUG DATOS FIL] Desviación estándar: {data_array.std():.3f}")
+        logger.debug("[DEBUG DATOS FIL] " + "="*50)
     
     return data_array
 
@@ -227,8 +227,8 @@ def get_obparams_fil(file_name: str) -> None:
     
                                                
     if config.DEBUG_FREQUENCY_ORDER:
-        logger.debug(f" FILTERBANK] Iniciando extracción de parámetros de: {file_name}")
-        logger.debug(f" FILTERBANK] " + "="*60)
+        logger.debug(f"[DEBUG FILTERBANK] Iniciando extracción de parámetros de: {file_name}")
+        logger.debug(f"[DEBUG FILTERBANK] " + "="*60)
     
     with open(file_name, "rb") as f:
         freq_axis_inverted = False
@@ -244,12 +244,12 @@ def get_obparams_fil(file_name: str) -> None:
 
                                                   
         if config.DEBUG_FREQUENCY_ORDER:
-            logger.debug(f" FILTERBANK] Estructura del archivo Filterbank:")
-            logger.debug(f" FILTERBANK]   Formato: SIGPROC Filterbank (.fil)")
-            logger.debug(f" FILTERBANK]   Tamaño del header: {hdr_len} bytes")
-            logger.debug(f" FILTERBANK] Headers extraídos del archivo .fil:")
+            logger.debug(f"[DEBUG FILTERBANK] Estructura del archivo Filterbank:")
+            logger.debug(f"[DEBUG FILTERBANK]   Formato: SIGPROC Filterbank (.fil)")
+            logger.debug(f"[DEBUG FILTERBANK]   Tamaño del header: {hdr_len} bytes")
+            logger.debug(f"[DEBUG FILTERBANK] Headers extraídos del archivo .fil:")
             for key, value in header.items():
-                logger.debug(f" FILTERBANK]   {key}: {value}")
+                logger.debug(f"[DEBUG FILTERBANK]   {key}: {value}")
 
         nchans = header.get("nchans", 512)
         tsamp = header.get("tsamp", 8.192e-5)
@@ -264,43 +264,43 @@ def get_obparams_fil(file_name: str) -> None:
             
             if config.DEBUG_FREQUENCY_ORDER:
                 logger.debug(f" FILTERBANK] nsamples no en header, calculando:")
-                logger.debug(f" FILTERBANK]   Tamaño archivo: {file_size} bytes")
-                logger.debug(f" FILTERBANK]   Bytes por muestra: {bytes_per_sample}")
-                logger.debug(f" FILTERBANK]   Muestras calculadas: {nsamples}")
+                logger.debug(f"[DEBUG FILTERBANK]   Tamaño archivo: {file_size} bytes")
+                logger.debug(f"[DEBUG FILTERBANK]   Bytes por muestra: {bytes_per_sample}")
+                logger.debug(f"[DEBUG FILTERBANK]   Muestras calculadas: {nsamples}")
 
                                                          
         if config.DEBUG_FREQUENCY_ORDER:
-            logger.debug(f" FILTERBANK]   tsamp (resolución temporal): {tsamp:.2e} s")
-            logger.debug(f" FILTERBANK]   nchans (canales): {nchans}")
-            logger.debug(f" FILTERBANK]   nifs (polarizaciones): {nifs}")
-            logger.debug(f" FILTERBANK]   nbits (bits por muestra): {nbits}")
+            logger.debug(f"[DEBUG FILTERBANK]   tsamp (resolución temporal): {tsamp:.2e} s")
+            logger.debug(f"[DEBUG FILTERBANK]   nchans (canales): {nchans}")
+            logger.debug(f"[DEBUG FILTERBANK]   nifs (polarizaciones): {nifs}")
+            logger.debug(f"[DEBUG FILTERBANK]   nbits (bits por muestra): {nbits}")
             if 'telescope_id' in header:
-                logger.debug(f" FILTERBANK]   telescope_id: {header['telescope_id']}")
+                logger.debug(f"[DEBUG FILTERBANK]   telescope_id: {header['telescope_id']}")
             if 'source_name' in header:
-                logger.debug(f" FILTERBANK]   Fuente: {header['source_name']}")
-            logger.debug(f" FILTERBANK]   Total de muestras: {nsamples}")
+                logger.debug(f"[DEBUG FILTERBANK]   Fuente: {header['source_name']}")
+            logger.debug(f"[DEBUG FILTERBANK]   Total de muestras: {nsamples}")
             
-            logger.debug(f" FILTERBANK] Análisis de frecuencias:")
-            logger.debug(f" FILTERBANK]   fch1 (freq inicial): {fch1} MHz")
-            logger.debug(f" FILTERBANK]   foff (ancho canal): {foff} MHz")
-            logger.debug(f" FILTERBANK]   Primeras 5 freq calculadas: {freq_temp[:5]}")
-            logger.debug(f" FILTERBANK]   Últimas 5 freq calculadas: {freq_temp[-5:]}")
+            logger.debug(f"[DEBUG FILTERBANK] Análisis de frecuencias:")
+            logger.debug(f"[DEBUG FILTERBANK]   fch1 (freq inicial): {fch1} MHz")
+            logger.debug(f"[DEBUG FILTERBANK]   foff (ancho canal): {foff} MHz")
+            logger.debug(f"[DEBUG FILTERBANK]   Primeras 5 freq calculadas: {freq_temp[:5]}")
+            logger.debug(f"[DEBUG FILTERBANK]   Últimas 5 freq calculadas: {freq_temp[-5:]}")
         
                                                               
         if foff < 0:
             freq_axis_inverted = True
             if config.DEBUG_FREQUENCY_ORDER:
-                logger.debug(f" FILTERBANK] foff negativo - frecuencias invertidas!")
+                logger.debug(f"[DEBUG FILTERBANK] foff negativo - frecuencias invertidas!")
         elif len(freq_temp) > 1 and freq_temp[0] > freq_temp[-1]:
             freq_axis_inverted = True
             if config.DEBUG_FREQUENCY_ORDER:
-                logger.debug(f" FILTERBANK] Frecuencias detectadas en orden descendente!")
+                logger.debug(f"[DEBUG FILTERBANK] Frecuencias detectadas en orden descendente!")
         else:
                                                                                                             
                                                                  
             freq_axis_inverted = True
             if config.DEBUG_FREQUENCY_ORDER:
-                logger.debug(f" FILTERBANK] foff positivo - invirtiendo para estándar radioastronomía!")
+                logger.debug(f"[DEBUG FILTERBANK] foff positivo - invirtiendo para estándar radioastronomía!")
         
                                                         
         if freq_axis_inverted:
@@ -324,61 +324,61 @@ def get_obparams_fil(file_name: str) -> None:
 
                                              
     if config.DEBUG_FREQUENCY_ORDER:
-        logger.debug(f" ARCHIVO FIL] Información completa del archivo: {file_name}")
-        logger.debug(f" ARCHIVO FIL] " + "="*60)
-        logger.debug(f" ARCHIVO FIL] DIMENSIONES Y RESOLUCIÓN:")
-        logger.debug(f" ARCHIVO FIL]   - Resolución temporal: {config.TIME_RESO:.2e} segundos/muestra")
-        logger.debug(f" ARCHIVO FIL]   - Resolución de frecuencia: {config.FREQ_RESO} canales")
-        logger.debug(f" ARCHIVO FIL]   - Longitud del archivo: {config.FILE_LENG:,} muestras")
-        logger.debug(f" ARCHIVO FIL]   - Bits por muestra: {nbits}")
-        logger.debug(f" ARCHIVO FIL]   - Polarizaciones: {nifs}")
+        logger.debug(f"[DEBUG ARCHIVO FIL] Información completa del archivo: {file_name}")
+        logger.debug(f"[DEBUG ARCHIVO FIL] " + "="*60)
+        logger.debug(f"[DEBUG ARCHIVO FIL] DIMENSIONES Y RESOLUCIÓN:")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Resolución temporal: {config.TIME_RESO:.2e} segundos/muestra")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Resolución de frecuencia: {config.FREQ_RESO} canales")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Longitud del archivo: {config.FILE_LENG:,} muestras")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Bits por muestra: {nbits}")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Polarizaciones: {nifs}")
         
                                  
         duracion_total_seg = config.FILE_LENG * config.TIME_RESO
         duracion_min = duracion_total_seg / 60
         duracion_horas = duracion_min / 60
-        logger.debug(f" ARCHIVO FIL]   - Duración total: {duracion_total_seg:.2f} seg ({duracion_min:.2f} min, {duracion_horas:.2f} h)")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Duración total: {duracion_total_seg:.2f} seg ({duracion_min:.2f} min, {duracion_horas:.2f} h)")
         
-        logger.debug(f" ARCHIVO FIL] FRECUENCIAS:")
-        logger.debug(f" ARCHIVO FIL]   - Rango total: {config.FREQ.min():.2f} - {config.FREQ.max():.2f} MHz")
-        logger.debug(f" ARCHIVO FIL]   - Ancho de banda: {abs(config.FREQ.max() - config.FREQ.min()):.2f} MHz")
-        logger.debug(f" ARCHIVO FIL]   - Resolución por canal: {abs(foff):.4f} MHz/canal")
-        logger.debug(f" ARCHIVO FIL]   - Orden original: {'DESCENDENTE (foff<0)' if foff < 0 else 'ASCENDENTE (foff>0)'}")
-        logger.debug(f" ARCHIVO FIL]   - Orden final (post-corrección): {'ASCENDENTE' if config.FREQ[0] < config.FREQ[-1] else 'DESCENDENTE'}")
+        logger.debug(f"[DEBUG ARCHIVO FIL] FRECUENCIAS:")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Rango total: {config.FREQ.min():.2f} - {config.FREQ.max():.2f} MHz")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Ancho de banda: {abs(config.FREQ.max() - config.FREQ.min()):.2f} MHz")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Resolución por canal: {abs(foff):.4f} MHz/canal")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Orden original: {'DESCENDENTE (foff<0)' if foff < 0 else 'ASCENDENTE (foff>0)'}")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Orden final (post-corrección): {'ASCENDENTE' if config.FREQ[0] < config.FREQ[-1] else 'DESCENDENTE'}")
         
-        logger.debug(f" ARCHIVO FIL] DECIMACIÓN:")
-        logger.debug(f" ARCHIVO FIL]   - Factor reducción frecuencia: {config.DOWN_FREQ_RATE}x")
-        logger.debug(f" ARCHIVO FIL]   - Factor reducción tiempo: {config.DOWN_TIME_RATE}x")
-        logger.debug(f" ARCHIVO FIL]   - Canales después de decimación: {config.FREQ_RESO // config.DOWN_FREQ_RATE}")
-        logger.debug(f" ARCHIVO FIL]   - Resolución temporal después: {config.TIME_RESO * config.DOWN_TIME_RATE:.2e} seg/muestra")
+        logger.debug(f"[DEBUG ARCHIVO FIL] DECIMACIÓN:")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Factor reducción frecuencia: {config.DOWN_FREQ_RATE}x")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Factor reducción tiempo: {config.DOWN_TIME_RATE}x")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Canales después de decimación: {config.FREQ_RESO // config.DOWN_FREQ_RATE}")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Resolución temporal después: {config.TIME_RESO * config.DOWN_TIME_RATE:.2e} seg/muestra")
         
                                              
         size_original_gb = (config.FILE_LENG * config.FREQ_RESO * (nbits/8)) / (1024**3)
         size_decimated_gb = size_original_gb / (config.DOWN_FREQ_RATE * config.DOWN_TIME_RATE)
-        logger.debug(f" ARCHIVO FIL] TAMAÑO ESTIMADO:")
-        logger.debug(f" ARCHIVO FIL]   - Datos originales: ~{size_original_gb:.2f} GB")
-        logger.debug(f" ARCHIVO FIL]   - Datos después decimación: ~{size_decimated_gb:.2f} GB")
+        logger.debug(f"[DEBUG ARCHIVO FIL] TAMAÑO ESTIMADO:")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Datos originales: ~{size_original_gb:.2f} GB")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Datos después decimación: ~{size_decimated_gb:.2f} GB")
         
         
-        logger.debug(f" ARCHIVO FIL] PROCESAMIENTO:")
-        logger.debug(f" ARCHIVO FIL]   - Multi-banda habilitado: {'SÍ' if config.USE_MULTI_BAND else 'NO'}")
-        logger.debug(f" ARCHIVO FIL]   - DM rango: {config.DM_min} - {config.DM_max} pc cm⁻³")
-        logger.debug(f" ARCHIVO FIL]   - Umbrales: DET_PROB={config.DET_PROB}, CLASS_PROB={config.CLASS_PROB}, SNR_THRESH={config.SNR_THRESH}")
-        logger.debug(f" ARCHIVO FIL] " + "="*60)
+        logger.debug(f"[DEBUG ARCHIVO FIL] PROCESAMIENTO:")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Multi-banda habilitado: {'SÍ' if config.USE_MULTI_BAND else 'NO'}")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - DM rango: {config.DM_min} - {config.DM_max} pc cm⁻³")
+        logger.debug(f"[DEBUG ARCHIVO FIL]   - Umbrales: DET_PROB={config.DET_PROB}, CLASS_PROB={config.CLASS_PROB}, SNR_THRESH={config.SNR_THRESH}")
+        logger.debug(f"[DEBUG ARCHIVO FIL] " + "="*60)
 
                                               
     if config.DEBUG_FREQUENCY_ORDER:
-        logger.debug(f" CONFIG FINAL FIL] Configuración final después de get_obparams_fil:")
-        logger.debug(f" CONFIG FINAL FIL] " + "="*60)
-        logger.debug(f" CONFIG FINAL FIL] DOWN_FREQ_RATE calculado: {config.DOWN_FREQ_RATE}x")
-        logger.debug(f" CONFIG FINAL FIL] DOWN_TIME_RATE calculado: {config.DOWN_TIME_RATE}x")
-        logger.debug(f" CONFIG FINAL FIL] Datos después de decimación:")
-        logger.debug(f" CONFIG FINAL FIL]   - Canales: {config.FREQ_RESO // config.DOWN_FREQ_RATE}")
-        logger.debug(f" CONFIG FINAL FIL]   - Resolución temporal: {config.TIME_RESO * config.DOWN_TIME_RATE:.2e} s/muestra")
-        logger.debug(f" CONFIG FINAL FIL]   - Reducción total de datos: {config.DOWN_FREQ_RATE * config.DOWN_TIME_RATE}x")
-        logger.debug(f" CONFIG FINAL FIL] DATA_NEEDS_REVERSAL final: {config.DATA_NEEDS_REVERSAL}")
-        logger.debug(f" CONFIG FINAL FIL] Orden de frecuencias final: {'ASCENDENTE' if config.FREQ[0] < config.FREQ[-1] else 'DESCENDENTE'}")
-        logger.debug(f" CONFIG FINAL FIL] " + "="*60)
+        logger.debug(f"[DEBUG CONFIG FINAL FIL] Configuración final después de get_obparams_fil:")
+        logger.debug(f"[DEBUG CONFIG FINAL FIL] " + "="*60)
+        logger.debug(f"[DEBUG CONFIG FINAL FIL] DOWN_FREQ_RATE calculado: {config.DOWN_FREQ_RATE}x")
+        logger.debug(f"[DEBUG CONFIG FINAL FIL] DOWN_TIME_RATE calculado: {config.DOWN_TIME_RATE}x")
+        logger.debug(f"[DEBUG CONFIG FINAL FIL] Datos después de decimación:")
+        logger.debug(f"[DEBUG CONFIG FINAL FIL]   - Canales: {config.FREQ_RESO // config.DOWN_FREQ_RATE}")
+        logger.debug(f"[DEBUG CONFIG FINAL FIL]   - Resolución temporal: {config.TIME_RESO * config.DOWN_TIME_RATE:.2e} s/muestra")
+        logger.debug(f"[DEBUG CONFIG FINAL FIL]   - Reducción total de datos: {config.DOWN_FREQ_RATE * config.DOWN_TIME_RATE}x")
+        logger.debug(f"[DEBUG CONFIG FINAL FIL] DATA_NEEDS_REVERSAL final: {config.DATA_NEEDS_REVERSAL}")
+        logger.debug(f"[DEBUG CONFIG FINAL FIL] Orden de frecuencias final: {'ASCENDENTE' if config.FREQ[0] < config.FREQ[-1] else 'DESCENDENTE'}")
+        logger.debug(f"[DEBUG CONFIG FINAL FIL] " + "="*60)
 
     logger.info("Filterbank parameters loaded successfully:")
     logger.debug("  - Channels: %d", nchans)
@@ -576,5 +576,5 @@ def stream_fil(
         del data_mmap
         
     except Exception as e:
-        logger.debug(f"[ERROR] Error en stream_fil: {e}")
+        logger.debug(f"[DEBUG ERROR] Error en stream_fil: {e}")
         raise ValueError(f"No se pudo leer el archivo {file_name}") from e

--- a/src/input/filterbank_handler.py
+++ b/src/input/filterbank_handler.py
@@ -9,6 +9,7 @@ import struct
 from typing import Dict, Generator, Tuple, Type
 
 import numpy as np
+import logging
 
                
 from ..config import config
@@ -18,6 +19,9 @@ from ..logging import (
     log_stream_fil_summary
 )
 from .utils import safe_float, safe_int, auto_config_downsampling, print_debug_frequencies, save_file_debug_info
+
+
+logger = logging.getLogger(__name__)
 
 
 def _read_int(f) -> int:
@@ -86,18 +90,18 @@ def _read_header(f) -> Tuple[dict, int]:
                                                               
                     header[key] = _read_int(f)
             except (struct.error, UnicodeDecodeError) as e:
-                print(f"Warning: Error reading header field '{key}': {e}")
+                logger.debug(f"Warning: Error reading header field '{key}': {e}")
                 continue
         return header, f.tell()
     except Exception as e:
-        print(f"Error reading standard filterbank header: {e}")
+        logger.debug(f"Error reading standard filterbank header: {e}")
         f.seek(original_pos)
         return _read_non_standard_header(f)
 
 
 def _read_non_standard_header(f) -> Tuple[dict, int]:
     """Handle non-standard filterbank files by assuming common parameters."""
-    print("[INFO] Detectado archivo .fil con formato no estándar, usando parámetros estimados")
+    logger.info("Detected non-standard .fil file; using estimated parameters")
     
                                           
     current_pos = f.tell()
@@ -121,10 +125,10 @@ def _read_non_standard_header(f) -> Tuple[dict, int]:
     max_samples = config.MAX_SAMPLES_LIMIT
     header["nsamples"] = min(estimated_samples, max_samples)
     
-    print(f"[INFO] Parámetros estimados para archivo no estándar:")
-    print(f"  - Tamaño de archivo: {file_size / (1024**2):.1f} MB")
-    print(f"  - Muestras estimadas: {estimated_samples}")
-    print(f"  - Muestras a usar: {header['nsamples']}")
+    logger.info("Estimated parameters for non-standard file:")
+    logger.debug("  - File size: %.1f MB", file_size / (1024**2))
+    logger.debug("  - Estimated samples: %d", estimated_samples)
+    logger.debug("  - Samples used: %d", header['nsamples'])
     
     return header, 512
 
@@ -158,7 +162,12 @@ def load_fil_file(file_name: str) -> np.ndarray:
         
         dtype = dtype_map.get(nbits, np.uint8)
             
-        print(f"[INFO] Cargando datos: {nsamples} muestras, {nchans} canales, tipo {dtype}")
+        logger.info(
+            "Loading filterbank data: samples=%d, channels=%d, dtype=%s",
+            nsamples,
+            nchans,
+            dtype,
+        )
         
                              
         try:
@@ -171,7 +180,7 @@ def load_fil_file(file_name: str) -> np.ndarray:
             )
             data_array = np.array(data)
         except ValueError as e:
-            print(f"[WARNING] Error creating memmap: {e}")
+            logger.warning("Error creating memmap: %s", e)
             safe_samples = min(nsamples, 10000)
             data = np.memmap(
                 file_name,
@@ -183,7 +192,7 @@ def load_fil_file(file_name: str) -> np.ndarray:
             data_array = np.array(data)
             
     except Exception as e:
-        print(f"[Error cargando FIL] {e}")
+        logger.error("Error loading filterbank file with numpy: %s", e)
         try:
                                         
             data_array = np.random.rand(1000, 1, 512).astype(np.float32)
@@ -194,21 +203,21 @@ def load_fil_file(file_name: str) -> np.ndarray:
         raise ValueError(f"No se pudieron cargar los datos de {file_name}")
 
     if global_vars.DATA_NEEDS_REVERSAL:
-        print(f">> Invirtiendo eje de frecuencia de los datos cargados para {file_name}")
+        logger.debug(f">> Invirtiendo eje de frecuencia de los datos cargados para {file_name}")
         data_array = np.ascontiguousarray(data_array[:, :, ::-1])
     
                                               
     if config.DEBUG_FREQUENCY_ORDER:
-        print(f"[DEBUG DATOS FIL] Archivo: {file_name}")
-        print(f"[DEBUG DATOS FIL] Shape de datos: {data_array.shape}")
-        print(f"[DEBUG DATOS FIL] Dimensiones: (tiempo={data_array.shape[0]}, pol={data_array.shape[1]}, freq={data_array.shape[2]})")
-        print(f"[DEBUG DATOS FIL] Tipo de datos: {data_array.dtype}")
-        print(f"[DEBUG DATOS FIL] Tamaño en memoria: {data_array.nbytes / (1024**3):.2f} GB")
-        print(f"[DEBUG DATOS FIL] Reversión aplicada: {global_vars.DATA_NEEDS_REVERSAL}")
-        print(f"[DEBUG DATOS FIL] Rango de valores: [{data_array.min():.3f}, {data_array.max():.3f}]")
-        print(f"[DEBUG DATOS FIL] Valor medio: {data_array.mean():.3f}")
-        print(f"[DEBUG DATOS FIL] Desviación estándar: {data_array.std():.3f}")
-        print("[DEBUG DATOS FIL] " + "="*50)
+        logger.debug(f" DATOS FIL] Archivo: {file_name}")
+        logger.debug(f" DATOS FIL] Shape de datos: {data_array.shape}")
+        logger.debug(f" DATOS FIL] Dimensiones: (tiempo={data_array.shape[0]}, pol={data_array.shape[1]}, freq={data_array.shape[2]})")
+        logger.debug(f" DATOS FIL] Tipo de datos: {data_array.dtype}")
+        logger.debug(f" DATOS FIL] Tamaño en memoria: {data_array.nbytes / (1024**3):.2f} GB")
+        logger.debug(f" DATOS FIL] Reversión aplicada: {global_vars.DATA_NEEDS_REVERSAL}")
+        logger.debug(f" DATOS FIL] Rango de valores: [{data_array.min():.3f}, {data_array.max():.3f}]")
+        logger.debug(f" DATOS FIL] Valor medio: {data_array.mean():.3f}")
+        logger.debug(f" DATOS FIL] Desviación estándar: {data_array.std():.3f}")
+        logger.debug(" DATOS FIL] " + "="*50)
     
     return data_array
 
@@ -218,8 +227,8 @@ def get_obparams_fil(file_name: str) -> None:
     
                                                
     if config.DEBUG_FREQUENCY_ORDER:
-        print(f"[DEBUG FILTERBANK] Iniciando extracción de parámetros de: {file_name}")
-        print(f"[DEBUG FILTERBANK] " + "="*60)
+        logger.debug(f" FILTERBANK] Iniciando extracción de parámetros de: {file_name}")
+        logger.debug(f" FILTERBANK] " + "="*60)
     
     with open(file_name, "rb") as f:
         freq_axis_inverted = False
@@ -235,12 +244,12 @@ def get_obparams_fil(file_name: str) -> None:
 
                                                   
         if config.DEBUG_FREQUENCY_ORDER:
-            print(f"[DEBUG FILTERBANK] Estructura del archivo Filterbank:")
-            print(f"[DEBUG FILTERBANK]   Formato: SIGPROC Filterbank (.fil)")
-            print(f"[DEBUG FILTERBANK]   Tamaño del header: {hdr_len} bytes")
-            print(f"[DEBUG FILTERBANK] Headers extraídos del archivo .fil:")
+            logger.debug(f" FILTERBANK] Estructura del archivo Filterbank:")
+            logger.debug(f" FILTERBANK]   Formato: SIGPROC Filterbank (.fil)")
+            logger.debug(f" FILTERBANK]   Tamaño del header: {hdr_len} bytes")
+            logger.debug(f" FILTERBANK] Headers extraídos del archivo .fil:")
             for key, value in header.items():
-                print(f"[DEBUG FILTERBANK]   {key}: {value}")
+                logger.debug(f" FILTERBANK]   {key}: {value}")
 
         nchans = header.get("nchans", 512)
         tsamp = header.get("tsamp", 8.192e-5)
@@ -254,44 +263,44 @@ def get_obparams_fil(file_name: str) -> None:
             nsamples = file_size // bytes_per_sample if bytes_per_sample > 0 else 1000
             
             if config.DEBUG_FREQUENCY_ORDER:
-                print(f"[DEBUG FILTERBANK] nsamples no en header, calculando:")
-                print(f"[DEBUG FILTERBANK]   Tamaño archivo: {file_size} bytes")
-                print(f"[DEBUG FILTERBANK]   Bytes por muestra: {bytes_per_sample}")
-                print(f"[DEBUG FILTERBANK]   Muestras calculadas: {nsamples}")
+                logger.debug(f" FILTERBANK] nsamples no en header, calculando:")
+                logger.debug(f" FILTERBANK]   Tamaño archivo: {file_size} bytes")
+                logger.debug(f" FILTERBANK]   Bytes por muestra: {bytes_per_sample}")
+                logger.debug(f" FILTERBANK]   Muestras calculadas: {nsamples}")
 
                                                          
         if config.DEBUG_FREQUENCY_ORDER:
-            print(f"[DEBUG FILTERBANK]   tsamp (resolución temporal): {tsamp:.2e} s")
-            print(f"[DEBUG FILTERBANK]   nchans (canales): {nchans}")
-            print(f"[DEBUG FILTERBANK]   nifs (polarizaciones): {nifs}")
-            print(f"[DEBUG FILTERBANK]   nbits (bits por muestra): {nbits}")
+            logger.debug(f" FILTERBANK]   tsamp (resolución temporal): {tsamp:.2e} s")
+            logger.debug(f" FILTERBANK]   nchans (canales): {nchans}")
+            logger.debug(f" FILTERBANK]   nifs (polarizaciones): {nifs}")
+            logger.debug(f" FILTERBANK]   nbits (bits por muestra): {nbits}")
             if 'telescope_id' in header:
-                print(f"[DEBUG FILTERBANK]   telescope_id: {header['telescope_id']}")
+                logger.debug(f" FILTERBANK]   telescope_id: {header['telescope_id']}")
             if 'source_name' in header:
-                print(f"[DEBUG FILTERBANK]   Fuente: {header['source_name']}")
-            print(f"[DEBUG FILTERBANK]   Total de muestras: {nsamples}")
+                logger.debug(f" FILTERBANK]   Fuente: {header['source_name']}")
+            logger.debug(f" FILTERBANK]   Total de muestras: {nsamples}")
             
-            print(f"[DEBUG FILTERBANK] Análisis de frecuencias:")
-            print(f"[DEBUG FILTERBANK]   fch1 (freq inicial): {fch1} MHz")
-            print(f"[DEBUG FILTERBANK]   foff (ancho canal): {foff} MHz")
-            print(f"[DEBUG FILTERBANK]   Primeras 5 freq calculadas: {freq_temp[:5]}")
-            print(f"[DEBUG FILTERBANK]   Últimas 5 freq calculadas: {freq_temp[-5:]}")
+            logger.debug(f" FILTERBANK] Análisis de frecuencias:")
+            logger.debug(f" FILTERBANK]   fch1 (freq inicial): {fch1} MHz")
+            logger.debug(f" FILTERBANK]   foff (ancho canal): {foff} MHz")
+            logger.debug(f" FILTERBANK]   Primeras 5 freq calculadas: {freq_temp[:5]}")
+            logger.debug(f" FILTERBANK]   Últimas 5 freq calculadas: {freq_temp[-5:]}")
         
                                                               
         if foff < 0:
             freq_axis_inverted = True
             if config.DEBUG_FREQUENCY_ORDER:
-                print(f"[DEBUG FILTERBANK] foff negativo - frecuencias invertidas!")
+                logger.debug(f" FILTERBANK] foff negativo - frecuencias invertidas!")
         elif len(freq_temp) > 1 and freq_temp[0] > freq_temp[-1]:
             freq_axis_inverted = True
             if config.DEBUG_FREQUENCY_ORDER:
-                print(f"[DEBUG FILTERBANK] Frecuencias detectadas en orden descendente!")
+                logger.debug(f" FILTERBANK] Frecuencias detectadas en orden descendente!")
         else:
                                                                                                             
                                                                  
             freq_axis_inverted = True
             if config.DEBUG_FREQUENCY_ORDER:
-                print(f"[DEBUG FILTERBANK] foff positivo - invirtiendo para estándar radioastronomía!")
+                logger.debug(f" FILTERBANK] foff positivo - invirtiendo para estándar radioastronomía!")
         
                                                         
         if freq_axis_inverted:
@@ -315,70 +324,70 @@ def get_obparams_fil(file_name: str) -> None:
 
                                              
     if config.DEBUG_FREQUENCY_ORDER:
-        print(f"[DEBUG ARCHIVO FIL] Información completa del archivo: {file_name}")
-        print(f"[DEBUG ARCHIVO FIL] " + "="*60)
-        print(f"[DEBUG ARCHIVO FIL] DIMENSIONES Y RESOLUCIÓN:")
-        print(f"[DEBUG ARCHIVO FIL]   - Resolución temporal: {config.TIME_RESO:.2e} segundos/muestra")
-        print(f"[DEBUG ARCHIVO FIL]   - Resolución de frecuencia: {config.FREQ_RESO} canales")
-        print(f"[DEBUG ARCHIVO FIL]   - Longitud del archivo: {config.FILE_LENG:,} muestras")
-        print(f"[DEBUG ARCHIVO FIL]   - Bits por muestra: {nbits}")
-        print(f"[DEBUG ARCHIVO FIL]   - Polarizaciones: {nifs}")
+        logger.debug(f" ARCHIVO FIL] Información completa del archivo: {file_name}")
+        logger.debug(f" ARCHIVO FIL] " + "="*60)
+        logger.debug(f" ARCHIVO FIL] DIMENSIONES Y RESOLUCIÓN:")
+        logger.debug(f" ARCHIVO FIL]   - Resolución temporal: {config.TIME_RESO:.2e} segundos/muestra")
+        logger.debug(f" ARCHIVO FIL]   - Resolución de frecuencia: {config.FREQ_RESO} canales")
+        logger.debug(f" ARCHIVO FIL]   - Longitud del archivo: {config.FILE_LENG:,} muestras")
+        logger.debug(f" ARCHIVO FIL]   - Bits por muestra: {nbits}")
+        logger.debug(f" ARCHIVO FIL]   - Polarizaciones: {nifs}")
         
                                  
         duracion_total_seg = config.FILE_LENG * config.TIME_RESO
         duracion_min = duracion_total_seg / 60
         duracion_horas = duracion_min / 60
-        print(f"[DEBUG ARCHIVO FIL]   - Duración total: {duracion_total_seg:.2f} seg ({duracion_min:.2f} min, {duracion_horas:.2f} h)")
+        logger.debug(f" ARCHIVO FIL]   - Duración total: {duracion_total_seg:.2f} seg ({duracion_min:.2f} min, {duracion_horas:.2f} h)")
         
-        print(f"[DEBUG ARCHIVO FIL] FRECUENCIAS:")
-        print(f"[DEBUG ARCHIVO FIL]   - Rango total: {config.FREQ.min():.2f} - {config.FREQ.max():.2f} MHz")
-        print(f"[DEBUG ARCHIVO FIL]   - Ancho de banda: {abs(config.FREQ.max() - config.FREQ.min()):.2f} MHz")
-        print(f"[DEBUG ARCHIVO FIL]   - Resolución por canal: {abs(foff):.4f} MHz/canal")
-        print(f"[DEBUG ARCHIVO FIL]   - Orden original: {'DESCENDENTE (foff<0)' if foff < 0 else 'ASCENDENTE (foff>0)'}")
-        print(f"[DEBUG ARCHIVO FIL]   - Orden final (post-corrección): {'ASCENDENTE' if config.FREQ[0] < config.FREQ[-1] else 'DESCENDENTE'}")
+        logger.debug(f" ARCHIVO FIL] FRECUENCIAS:")
+        logger.debug(f" ARCHIVO FIL]   - Rango total: {config.FREQ.min():.2f} - {config.FREQ.max():.2f} MHz")
+        logger.debug(f" ARCHIVO FIL]   - Ancho de banda: {abs(config.FREQ.max() - config.FREQ.min()):.2f} MHz")
+        logger.debug(f" ARCHIVO FIL]   - Resolución por canal: {abs(foff):.4f} MHz/canal")
+        logger.debug(f" ARCHIVO FIL]   - Orden original: {'DESCENDENTE (foff<0)' if foff < 0 else 'ASCENDENTE (foff>0)'}")
+        logger.debug(f" ARCHIVO FIL]   - Orden final (post-corrección): {'ASCENDENTE' if config.FREQ[0] < config.FREQ[-1] else 'DESCENDENTE'}")
         
-        print(f"[DEBUG ARCHIVO FIL] DECIMACIÓN:")
-        print(f"[DEBUG ARCHIVO FIL]   - Factor reducción frecuencia: {config.DOWN_FREQ_RATE}x")
-        print(f"[DEBUG ARCHIVO FIL]   - Factor reducción tiempo: {config.DOWN_TIME_RATE}x")
-        print(f"[DEBUG ARCHIVO FIL]   - Canales después de decimación: {config.FREQ_RESO // config.DOWN_FREQ_RATE}")
-        print(f"[DEBUG ARCHIVO FIL]   - Resolución temporal después: {config.TIME_RESO * config.DOWN_TIME_RATE:.2e} seg/muestra")
+        logger.debug(f" ARCHIVO FIL] DECIMACIÓN:")
+        logger.debug(f" ARCHIVO FIL]   - Factor reducción frecuencia: {config.DOWN_FREQ_RATE}x")
+        logger.debug(f" ARCHIVO FIL]   - Factor reducción tiempo: {config.DOWN_TIME_RATE}x")
+        logger.debug(f" ARCHIVO FIL]   - Canales después de decimación: {config.FREQ_RESO // config.DOWN_FREQ_RATE}")
+        logger.debug(f" ARCHIVO FIL]   - Resolución temporal después: {config.TIME_RESO * config.DOWN_TIME_RATE:.2e} seg/muestra")
         
                                              
         size_original_gb = (config.FILE_LENG * config.FREQ_RESO * (nbits/8)) / (1024**3)
         size_decimated_gb = size_original_gb / (config.DOWN_FREQ_RATE * config.DOWN_TIME_RATE)
-        print(f"[DEBUG ARCHIVO FIL] TAMAÑO ESTIMADO:")
-        print(f"[DEBUG ARCHIVO FIL]   - Datos originales: ~{size_original_gb:.2f} GB")
-        print(f"[DEBUG ARCHIVO FIL]   - Datos después decimación: ~{size_decimated_gb:.2f} GB")
+        logger.debug(f" ARCHIVO FIL] TAMAÑO ESTIMADO:")
+        logger.debug(f" ARCHIVO FIL]   - Datos originales: ~{size_original_gb:.2f} GB")
+        logger.debug(f" ARCHIVO FIL]   - Datos después decimación: ~{size_decimated_gb:.2f} GB")
         
         
-        print(f"[DEBUG ARCHIVO FIL] PROCESAMIENTO:")
-        print(f"[DEBUG ARCHIVO FIL]   - Multi-banda habilitado: {'SÍ' if config.USE_MULTI_BAND else 'NO'}")
-        print(f"[DEBUG ARCHIVO FIL]   - DM rango: {config.DM_min} - {config.DM_max} pc cm⁻³")
-        print(f"[DEBUG ARCHIVO FIL]   - Umbrales: DET_PROB={config.DET_PROB}, CLASS_PROB={config.CLASS_PROB}, SNR_THRESH={config.SNR_THRESH}")
-        print(f"[DEBUG ARCHIVO FIL] " + "="*60)
+        logger.debug(f" ARCHIVO FIL] PROCESAMIENTO:")
+        logger.debug(f" ARCHIVO FIL]   - Multi-banda habilitado: {'SÍ' if config.USE_MULTI_BAND else 'NO'}")
+        logger.debug(f" ARCHIVO FIL]   - DM rango: {config.DM_min} - {config.DM_max} pc cm⁻³")
+        logger.debug(f" ARCHIVO FIL]   - Umbrales: DET_PROB={config.DET_PROB}, CLASS_PROB={config.CLASS_PROB}, SNR_THRESH={config.SNR_THRESH}")
+        logger.debug(f" ARCHIVO FIL] " + "="*60)
 
                                               
     if config.DEBUG_FREQUENCY_ORDER:
-        print(f"[DEBUG CONFIG FINAL FIL] Configuración final después de get_obparams_fil:")
-        print(f"[DEBUG CONFIG FINAL FIL] " + "="*60)
-        print(f"[DEBUG CONFIG FINAL FIL] DOWN_FREQ_RATE calculado: {config.DOWN_FREQ_RATE}x")
-        print(f"[DEBUG CONFIG FINAL FIL] DOWN_TIME_RATE calculado: {config.DOWN_TIME_RATE}x")
-        print(f"[DEBUG CONFIG FINAL FIL] Datos después de decimación:")
-        print(f"[DEBUG CONFIG FINAL FIL]   - Canales: {config.FREQ_RESO // config.DOWN_FREQ_RATE}")
-        print(f"[DEBUG CONFIG FINAL FIL]   - Resolución temporal: {config.TIME_RESO * config.DOWN_TIME_RATE:.2e} s/muestra")
-        print(f"[DEBUG CONFIG FINAL FIL]   - Reducción total de datos: {config.DOWN_FREQ_RATE * config.DOWN_TIME_RATE}x")
-        print(f"[DEBUG CONFIG FINAL FIL] DATA_NEEDS_REVERSAL final: {config.DATA_NEEDS_REVERSAL}")
-        print(f"[DEBUG CONFIG FINAL FIL] Orden de frecuencias final: {'ASCENDENTE' if config.FREQ[0] < config.FREQ[-1] else 'DESCENDENTE'}")
-        print(f"[DEBUG CONFIG FINAL FIL] " + "="*60)
+        logger.debug(f" CONFIG FINAL FIL] Configuración final después de get_obparams_fil:")
+        logger.debug(f" CONFIG FINAL FIL] " + "="*60)
+        logger.debug(f" CONFIG FINAL FIL] DOWN_FREQ_RATE calculado: {config.DOWN_FREQ_RATE}x")
+        logger.debug(f" CONFIG FINAL FIL] DOWN_TIME_RATE calculado: {config.DOWN_TIME_RATE}x")
+        logger.debug(f" CONFIG FINAL FIL] Datos después de decimación:")
+        logger.debug(f" CONFIG FINAL FIL]   - Canales: {config.FREQ_RESO // config.DOWN_FREQ_RATE}")
+        logger.debug(f" CONFIG FINAL FIL]   - Resolución temporal: {config.TIME_RESO * config.DOWN_TIME_RATE:.2e} s/muestra")
+        logger.debug(f" CONFIG FINAL FIL]   - Reducción total de datos: {config.DOWN_FREQ_RATE * config.DOWN_TIME_RATE}x")
+        logger.debug(f" CONFIG FINAL FIL] DATA_NEEDS_REVERSAL final: {config.DATA_NEEDS_REVERSAL}")
+        logger.debug(f" CONFIG FINAL FIL] Orden de frecuencias final: {'ASCENDENTE' if config.FREQ[0] < config.FREQ[-1] else 'DESCENDENTE'}")
+        logger.debug(f" CONFIG FINAL FIL] " + "="*60)
 
-    print(f"[INFO] Parámetros del archivo .fil cargados exitosamente:")
-    print(f"  - Canales: {nchans}")
-    print(f"  - Resolución temporal: {tsamp:.2e} s")
-    print(f"  - Frecuencia inicial: {fch1} MHz")
-    print(f"  - Ancho de banda: {foff} MHz")
-    print(f"  - Muestras: {nsamples}")
-    print(f"  - Down-sampling frecuencia: {config.DOWN_FREQ_RATE}")
-    print(f"  - Down-sampling tiempo: {config.DOWN_TIME_RATE}")
+    logger.info("Filterbank parameters loaded successfully:")
+    logger.debug("  - Channels: %d", nchans)
+    logger.debug("  - Time resolution: %.2e s", tsamp)
+    logger.debug("  - Start frequency: %.2f MHz", fch1)
+    logger.debug("  - Channel width: %.2f MHz", foff)
+    logger.debug("  - Samples: %d", nsamples)
+    logger.debug("  - Frequency downsampling: %d", config.DOWN_FREQ_RATE)
+    logger.debug("  - Time downsampling: %d", config.DOWN_TIME_RATE)
 
                                                                
     if config.DEBUG_FREQUENCY_ORDER:
@@ -490,8 +499,14 @@ def stream_fil(
         
         dtype = dtype_map.get(nbits, np.uint8)
         
-        print(f"[INFO] Streaming datos: {nsamples} muestras totales, "
-              f"{nchans} canales, tipo {dtype}, chunk_size={chunk_samples}, overlap={overlap_samples}")
+        logger.info(
+            "Streaming filterbank data: total_samples=%d, channels=%d, dtype=%s, chunk_size=%d, overlap=%d",
+            nsamples,
+            nchans,
+            dtype,
+            chunk_samples,
+            overlap_samples,
+        )
         
                                                                       
         log_stream_fil_parameters(nsamples, chunk_samples, overlap_samples, nchans, nifs, nbits, str(dtype))
@@ -561,5 +576,5 @@ def stream_fil(
         del data_mmap
         
     except Exception as e:
-        print(f"[ERROR] Error en stream_fil: {e}")
+        logger.debug(f"[ERROR] Error en stream_fil: {e}")
         raise ValueError(f"No se pudo leer el archivo {file_name}") from e

--- a/src/input/fits_handler.py
+++ b/src/input/fits_handler.py
@@ -440,16 +440,16 @@ def load_fits_file(file_name: str) -> np.ndarray:
     
                                               
     if config.DEBUG_FREQUENCY_ORDER:
-        logger.debug(f" DATOS CARGADOS] Archivo: {file_name}")
-        logger.debug(f" DATOS CARGADOS] Shape de datos: {data_array.shape}")
-        logger.debug(f" DATOS CARGADOS] Dimensiones: (tiempo={data_array.shape[0]}, pol={data_array.shape[1]}, freq={data_array.shape[2]})")
-        logger.debug(f" DATOS CARGADOS] Tipo de datos: {data_array.dtype}")
-        logger.debug(f" DATOS CARGADOS] Tamaño en memoria: {data_array.nbytes / (1024**3):.2f} GB")
-        logger.debug(f" DATOS CARGADOS] Reversión aplicada: {global_vars.DATA_NEEDS_REVERSAL}")
-        logger.debug(f" DATOS CARGADOS] Rango de valores: [{data_array.min():.3f}, {data_array.max():.3f}]")
-        logger.debug(f" DATOS CARGADOS] Valor medio: {data_array.mean():.3f}")
-        logger.debug(f" DATOS CARGADOS] Desviación estándar: {data_array.std():.3f}")
-        logger.debug(" DATOS CARGADOS] " + "="*50)
+        logger.debug(f"[DEBUG DATOS CARGADOS] Archivo: {file_name}")
+        logger.debug(f"[DEBUG DATOS CARGADOS] Shape de datos: {data_array.shape}")
+        logger.debug(f"[DEBUG DATOS CARGADOS] Dimensiones: (tiempo={data_array.shape[0]}, pol={data_array.shape[1]}, freq={data_array.shape[2]})")
+        logger.debug(f"[DEBUG DATOS CARGADOS] Tipo de datos: {data_array.dtype}")
+        logger.debug(f"[DEBUG DATOS CARGADOS] Tamaño en memoria: {data_array.nbytes / (1024**3):.2f} GB")
+        logger.debug(f"[DEBUG DATOS CARGADOS] Reversión aplicada: {global_vars.DATA_NEEDS_REVERSAL}")
+        logger.debug(f"[DEBUG DATOS CARGADOS] Rango de valores: [{data_array.min():.3f}, {data_array.max():.3f}]")
+        logger.debug(f"[DEBUG DATOS CARGADOS] Valor medio: {data_array.mean():.3f}")
+        logger.debug(f"[DEBUG DATOS CARGADOS] Desviación estándar: {data_array.std():.3f}")
+        logger.debug("[DEBUG DATOS CARGADOS] " + "="*50)
     
     return data_array
 
@@ -459,15 +459,15 @@ def get_obparams(file_name: str) -> None:
     
                                                
     if config.DEBUG_FREQUENCY_ORDER:
-        logger.debug(f" HEADER] Iniciando extracción de parámetros de: {file_name}")
-        logger.debug(f" HEADER] " + "="*60)
+        logger.debug(f"[DEBUG HEADER] Iniciando extracción de parámetros de: {file_name}")
+        logger.debug(f"[DEBUG HEADER] " + "="*60)
     
     with fits.open(file_name, memmap=True) as f:
         freq_axis_inverted = False
         
                                             
         if config.DEBUG_FREQUENCY_ORDER:
-            logger.debug(f" HEADER] Estructura del archivo FITS:")
+            logger.debug(f"[DEBUG HEADER] Estructura del archivo FITS:")
             for i, hdu in enumerate(f):
                 hdu_type = type(hdu).__name__
                 if hasattr(hdu, 'header') and hdu.header:
@@ -475,16 +475,16 @@ def get_obparams(file_name: str) -> None:
                         ext_name = hdu.header['EXTNAME']
                     else:
                         ext_name = 'PRIMARY' if i == 0 else f'HDU_{i}'
-                    logger.debug(f" HEADER]   HDU {i}: {hdu_type} - {ext_name}")
+                    logger.debug(f"[DEBUG HEADER]   HDU {i}: {hdu_type} - {ext_name}")
                     if hasattr(hdu, 'columns') and hdu.columns:
-                        logger.debug(f" HEADER]     Columnas: {[col.name for col in hdu.columns]}")
+                        logger.debug(f"[DEBUG HEADER]     Columnas: {[col.name for col in hdu.columns]}")
                 else:
-                    logger.debug(f" HEADER]   HDU {i}: {hdu_type} - Sin header")
+                    logger.debug(f"[DEBUG HEADER]   HDU {i}: {hdu_type} - Sin header")
         
         if "SUBINT" in [hdu.name for hdu in f] and "TBIN" in f["SUBINT"].header:
                                                
             if config.DEBUG_FREQUENCY_ORDER:
-                logger.debug(f" HEADER] Formato detectado: PSRFITS (SUBINT)")
+                logger.debug(f"[DEBUG HEADER] Formato detectado: PSRFITS (SUBINT)")
             
             hdr = f["SUBINT"].header
             primary = f["PRIMARY"].header if "PRIMARY" in [h.name for h in f] else {}
@@ -569,26 +569,26 @@ def get_obparams(file_name: str) -> None:
                 freq_temp = sub_data["DAT_FREQ"][0].astype(np.float64)
             except Exception as e:
                 if config.DEBUG_FREQUENCY_ORDER:
-                    logger.debug(f" HEADER] Error convirtiendo DAT_FREQ: {e}")
-                    logger.debug(" HEADER] Usando rango de frecuencias por defecto")
+                    logger.debug(f"[DEBUG HEADER] Error convirtiendo DAT_FREQ: {e}")
+                    logger.debug("[DEBUG HEADER] Usando rango de frecuencias por defecto")
                 nchan = safe_int(hdr.get("NCHAN", 512), 512)
                 freq_temp = np.linspace(1000, 1500, nchan)
             
                                                 
             if config.DEBUG_FREQUENCY_ORDER:
-                logger.debug(f" HEADER] Headers PSRFITS extraídos:")
+                logger.debug(f"[DEBUG HEADER] Headers PSRFITS extraídos:")
                 logger.debug(
                     f"[DEBUG HEADER]   TBIN (resolución temporal): {safe_float(hdr.get('TBIN')):.2e} s"
                 )
-                logger.debug(f" HEADER]   NCHAN (canales): {hdr['NCHAN']}")
-                logger.debug(f" HEADER]   NSBLK (muestras por subint): {hdr['NSBLK']}")
-                logger.debug(f" HEADER]   NAXIS2 (número de subints): {hdr['NAXIS2']}")
-                logger.debug(f" HEADER]   NPOL (polarizaciones): {hdr.get('NPOL', 'N/A')}")
-                logger.debug(f" HEADER]   Total de muestras: {config.FILE_LENG}")
+                logger.debug(f"[DEBUG HEADER]   NCHAN (canales): {hdr['NCHAN']}")
+                logger.debug(f"[DEBUG HEADER]   NSBLK (muestras por subint): {hdr['NSBLK']}")
+                logger.debug(f"[DEBUG HEADER]   NAXIS2 (número de subints): {hdr['NAXIS2']}")
+                logger.debug(f"[DEBUG HEADER]   NPOL (polarizaciones): {hdr.get('NPOL', 'N/A')}")
+                logger.debug(f"[DEBUG HEADER]   Total de muestras: {config.FILE_LENG}")
                 if 'OBS_MODE' in hdr:
-                    logger.debug(f" HEADER]   Modo de observación: {hdr['OBS_MODE']}")
+                    logger.debug(f"[DEBUG HEADER]   Modo de observación: {hdr['OBS_MODE']}")
                 if 'SRC_NAME' in hdr:
-                    logger.debug(f" HEADER]   Fuente: {hdr['SRC_NAME']}")
+                    logger.debug(f"[DEBUG HEADER]   Fuente: {hdr['SRC_NAME']}")
             
                                                                                           
             if len(freq_temp) > 1:
@@ -596,17 +596,17 @@ def get_obparams(file_name: str) -> None:
                 if df < 0:
                     freq_axis_inverted = True
                     if config.DEBUG_FREQUENCY_ORDER:
-                        logger.debug(f" HEADER] DAT_FREQ descendente → invertir banda (estilo PRESTO)")
+                        logger.debug(f"[DEBUG HEADER] DAT_FREQ descendente → invertir banda (estilo PRESTO)")
                 else:
                                                                                                                     
                                                                          
                     freq_axis_inverted = True
                     if config.DEBUG_FREQUENCY_ORDER:
-                        logger.debug(f" HEADER] DAT_FREQ ascendente → invertir banda (estilo radioastronomía)")
+                        logger.debug(f"[DEBUG HEADER] DAT_FREQ ascendente → invertir banda (estilo radioastronomía)")
         else:
                                                      
             if config.DEBUG_FREQUENCY_ORDER:
-                logger.debug(f" HEADER] Formato detectado: FITS estándar (no PSRFITS)")
+                logger.debug(f"[DEBUG HEADER] Formato detectado: FITS estándar (no PSRFITS)")
             
             try:
                 data_hdu_index = 0
@@ -627,31 +627,31 @@ def get_obparams(file_name: str) -> None:
                 
                                          
                 if config.DEBUG_FREQUENCY_ORDER:
-                    logger.debug(f" HEADER] HDU seleccionado para datos: {data_hdu_index}")
+                    logger.debug(f"[DEBUG HEADER] HDU seleccionado para datos: {data_hdu_index}")
                 
                 hdr = f[data_hdu_index].header
                 
                                               
                 if config.DEBUG_FREQUENCY_ORDER:
-                    logger.debug(f" HEADER] Headers FITS estándar del HDU {data_hdu_index}:")
+                    logger.debug(f"[DEBUG HEADER] Headers FITS estándar del HDU {data_hdu_index}:")
                     relevant_keys = ['TBIN', 'NCHAN', 'NAXIS2', 'NSBLK', 'NPOL', 'CRVAL1', 'CRVAL2', 'CRVAL3', 
                                    'CDELT1', 'CDELT2', 'CDELT3', 'CTYPE1', 'CTYPE2', 'CTYPE3']
                     for key in relevant_keys:
                         if key in hdr:
-                            logger.debug(f" HEADER]   {key}: {hdr[key]}")
+                            logger.debug(f"[DEBUG HEADER]   {key}: {hdr[key]}")
                 
                 if "DAT_FREQ" in f[data_hdu_index].columns.names:
                     try:
                         freq_temp = f[data_hdu_index].data["DAT_FREQ"][0].astype(np.float64)
                     except Exception as e:
                         if config.DEBUG_FREQUENCY_ORDER:
-                            logger.debug(f" HEADER] Error convirtiendo DAT_FREQ: {e}")
-                            logger.debug(" HEADER] Usando rango de frecuencias por defecto")
+                            logger.debug(f"[DEBUG HEADER] Error convirtiendo DAT_FREQ: {e}")
+                            logger.debug("[DEBUG HEADER] Usando rango de frecuencias por defecto")
                         nchan = safe_int(hdr.get("NCHAN", 512), 512)
                         freq_temp = np.linspace(1000, 1500, nchan)
                     else:
                         if config.DEBUG_FREQUENCY_ORDER:
-                            logger.debug(f" HEADER] Frecuencias extraídas de columna DAT_FREQ")
+                            logger.debug(f"[DEBUG HEADER] Frecuencias extraídas de columna DAT_FREQ")
                 else:
                     freq_axis_num = ''
                     for i in range(1, hdr.get('NAXIS', 0) + 1):
@@ -660,8 +660,8 @@ def get_obparams(file_name: str) -> None:
                             break
                     
                     if config.DEBUG_FREQUENCY_ORDER:
-                        logger.debug(f" HEADER] Buscando eje de frecuencias en headers WCS...")
-                        logger.debug(f" HEADER] Eje de frecuencias detectado: CTYPE{freq_axis_num}" if freq_axis_num else "[DEBUG HEADER] No se encontró eje de frecuencias")
+                        logger.debug(f"[DEBUG HEADER] Buscando eje de frecuencias en headers WCS...")
+                        logger.debug(f"[DEBUG HEADER] Eje de frecuencias detectado: CTYPE{freq_axis_num}" if freq_axis_num else "[DEBUG HEADER] No se encontró eje de frecuencias")
                     
                     if freq_axis_num:
                         crval = hdr.get(f'CRVAL{freq_axis_num}', 0)
@@ -681,24 +681,24 @@ def get_obparams(file_name: str) -> None:
                         freq_temp = crval + (np.arange(naxis) - (crpix - 1)) * cdelt
                         
                         if config.DEBUG_FREQUENCY_ORDER:
-                            logger.debug(f" HEADER] Parámetros WCS frecuencia:")
-                            logger.debug(f" HEADER]   CRVAL{freq_axis_num}: {crval} (valor de referencia)")
-                            logger.debug(f" HEADER]   CDELT{freq_axis_num}: {cdelt} (incremento por canal)")
-                            logger.debug(f" HEADER]   CRPIX{freq_axis_num}: {crpix} (pixel de referencia)")
-                            logger.debug(f" HEADER]   NAXIS{freq_axis_num}: {naxis} (número de canales)")
+                            logger.debug(f"[DEBUG HEADER] Parámetros WCS frecuencia:")
+                            logger.debug(f"[DEBUG HEADER]   CRVAL{freq_axis_num}: {crval} (valor de referencia)")
+                            logger.debug(f"[DEBUG HEADER]   CDELT{freq_axis_num}: {cdelt} (incremento por canal)")
+                            logger.debug(f"[DEBUG HEADER]   CRPIX{freq_axis_num}: {crpix} (pixel de referencia)")
+                            logger.debug(f"[DEBUG HEADER]   NAXIS{freq_axis_num}: {naxis} (número de canales)")
                         
                         if cdelt < 0:
                             freq_axis_inverted = True
                             if config.DEBUG_FREQUENCY_ORDER:
-                                logger.debug(f" HEADER]   [WARNING] CDELT negativo - frecuencias invertidas!")
+                                logger.debug(f"[DEBUG HEADER]   [WARNING] CDELT negativo - frecuencias invertidas!")
                         else:
                                                                                                                             
                             freq_axis_inverted = True
                             if config.DEBUG_FREQUENCY_ORDER:
-                                logger.debug(f" HEADER]   [WARNING] CDELT positivo - invirtiendo para estándar radioastronomía!")
+                                logger.debug(f"[DEBUG HEADER]   [WARNING] CDELT positivo - invirtiendo para estándar radioastronomía!")
                     else:
                         if config.DEBUG_FREQUENCY_ORDER:
-                            logger.debug(f" HEADER] [WARNING] Usando frecuencias por defecto: 1000-1500 MHz")
+                            logger.debug(f"[DEBUG HEADER] [WARNING] Usando frecuencias por defecto: 1000-1500 MHz")
                         freq_temp = np.linspace(1000, 1500, hdr.get('NCHAN', 512))
                 
                                                                                 
@@ -708,15 +708,15 @@ def get_obparams(file_name: str) -> None:
                 
                                                      
                 if config.DEBUG_FREQUENCY_ORDER:
-                    logger.debug(f" HEADER] Parámetros finales FITS estándar:")
-                    logger.debug(f" HEADER]   TIME_RESO: {config.TIME_RESO:.2e} s")
-                    logger.debug(f" HEADER]   FREQ_RESO: {config.FREQ_RESO}")
-                    logger.debug(f" HEADER]   FILE_LENG: {config.FILE_LENG}")
+                    logger.debug(f"[DEBUG HEADER] Parámetros finales FITS estándar:")
+                    logger.debug(f"[DEBUG HEADER]   TIME_RESO: {config.TIME_RESO:.2e} s")
+                    logger.debug(f"[DEBUG HEADER]   FREQ_RESO: {config.FREQ_RESO}")
+                    logger.debug(f"[DEBUG HEADER]   FILE_LENG: {config.FILE_LENG}")
                     
             except Exception as e_std:
                 if config.DEBUG_FREQUENCY_ORDER:
-                    logger.debug(f" HEADER] [WARNING] Error procesando FITS estándar: {e_std}")
-                    logger.debug(f" HEADER] Usando valores por defecto...")
+                    logger.debug(f"[DEBUG HEADER] [WARNING] Error procesando FITS estándar: {e_std}")
+                    logger.debug(f"[DEBUG HEADER] Usando valores por defecto...")
                 logger.debug(f"Error procesando FITS estándar: {e_std}")
                 config.TIME_RESO = 5.12e-5
                 config.FREQ_RESO = 512
@@ -744,68 +744,68 @@ def get_obparams(file_name: str) -> None:
 
                                              
     if config.DEBUG_FREQUENCY_ORDER:
-        logger.debug(f" ARCHIVO] Información completa del archivo: {file_name}")
-        logger.debug(f" ARCHIVO] " + "="*60)
-        logger.debug(f" ARCHIVO] DIMENSIONES Y RESOLUCIÓN:")
-        logger.debug(f" ARCHIVO]   - Resolución temporal: {config.TIME_RESO:.2e} segundos/muestra")
-        logger.debug(f" ARCHIVO]   - Resolución de frecuencia: {config.FREQ_RESO} canales")
-        logger.debug(f" ARCHIVO]   - Longitud del archivo: {config.FILE_LENG:,} muestras")
+        logger.debug(f"[DEBUG ARCHIVO] Información completa del archivo: {file_name}")
+        logger.debug(f"[DEBUG ARCHIVO] " + "="*60)
+        logger.debug(f"[DEBUG ARCHIVO] DIMENSIONES Y RESOLUCIÓN:")
+        logger.debug(f"[DEBUG ARCHIVO]   - Resolución temporal: {config.TIME_RESO:.2e} segundos/muestra")
+        logger.debug(f"[DEBUG ARCHIVO]   - Resolución de frecuencia: {config.FREQ_RESO} canales")
+        logger.debug(f"[DEBUG ARCHIVO]   - Longitud del archivo: {config.FILE_LENG:,} muestras")
         
                                  
         duracion_total_seg = config.FILE_LENG * config.TIME_RESO
         duracion_min = duracion_total_seg / 60
         duracion_horas = duracion_min / 60
-        logger.debug(f" ARCHIVO]   - Duración total: {duracion_total_seg:.2f} seg ({duracion_min:.2f} min, {duracion_horas:.2f} h)")
+        logger.debug(f"[DEBUG ARCHIVO]   - Duración total: {duracion_total_seg:.2f} seg ({duracion_min:.2f} min, {duracion_horas:.2f} h)")
         
-        logger.debug(f" ARCHIVO] FRECUENCIAS:")
-        logger.debug(f" ARCHIVO]   - Rango total: {config.FREQ.min():.2f} - {config.FREQ.max():.2f} MHz")
-        logger.debug(f" ARCHIVO]   - Ancho de banda: {abs(config.FREQ.max() - config.FREQ.min()):.2f} MHz")
-        logger.debug(f" ARCHIVO]   - Resolución por canal: {abs(config.FREQ[1] - config.FREQ[0]):.4f} MHz/canal")
-        logger.debug(f" ARCHIVO]   - Orden original: {'DESCENDENTE' if freq_axis_inverted else 'ASCENDENTE'}")
-        logger.debug(f" ARCHIVO]   - Orden final (post-corrección): {'ASCENDENTE' if config.FREQ[0] < config.FREQ[-1] else 'DESCENDENTE'}")
+        logger.debug(f"[DEBUG ARCHIVO] FRECUENCIAS:")
+        logger.debug(f"[DEBUG ARCHIVO]   - Rango total: {config.FREQ.min():.2f} - {config.FREQ.max():.2f} MHz")
+        logger.debug(f"[DEBUG ARCHIVO]   - Ancho de banda: {abs(config.FREQ.max() - config.FREQ.min()):.2f} MHz")
+        logger.debug(f"[DEBUG ARCHIVO]   - Resolución por canal: {abs(config.FREQ[1] - config.FREQ[0]):.4f} MHz/canal")
+        logger.debug(f"[DEBUG ARCHIVO]   - Orden original: {'DESCENDENTE' if freq_axis_inverted else 'ASCENDENTE'}")
+        logger.debug(f"[DEBUG ARCHIVO]   - Orden final (post-corrección): {'ASCENDENTE' if config.FREQ[0] < config.FREQ[-1] else 'DESCENDENTE'}")
         
-        logger.debug(f" ARCHIVO] DECIMACIÓN:")
-        logger.debug(f" ARCHIVO]   - Factor reducción frecuencia: {config.DOWN_FREQ_RATE}x")
-        logger.debug(f" ARCHIVO]   - Factor reducción tiempo: {config.DOWN_TIME_RATE}x")
-        logger.debug(f" ARCHIVO]   - Canales después de decimación: {config.FREQ_RESO // config.DOWN_FREQ_RATE}")
-        logger.debug(f" ARCHIVO]   - Resolución temporal después: {config.TIME_RESO * config.DOWN_TIME_RATE:.2e} seg/muestra")
+        logger.debug(f"[DEBUG ARCHIVO] DECIMACIÓN:")
+        logger.debug(f"[DEBUG ARCHIVO]   - Factor reducción frecuencia: {config.DOWN_FREQ_RATE}x")
+        logger.debug(f"[DEBUG ARCHIVO]   - Factor reducción tiempo: {config.DOWN_TIME_RATE}x")
+        logger.debug(f"[DEBUG ARCHIVO]   - Canales después de decimación: {config.FREQ_RESO // config.DOWN_FREQ_RATE}")
+        logger.debug(f"[DEBUG ARCHIVO]   - Resolución temporal después: {config.TIME_RESO * config.DOWN_TIME_RATE:.2e} seg/muestra")
         
                                              
         size_original_gb = (config.FILE_LENG * config.FREQ_RESO * 4) / (1024**3)                       
         size_decimated_gb = size_original_gb / (config.DOWN_FREQ_RATE * config.DOWN_TIME_RATE)
-        logger.debug(f" ARCHIVO] TAMAÑO ESTIMADO:")
-        logger.debug(f" ARCHIVO]   - Datos originales: ~{size_original_gb:.2f} GB")
-        logger.debug(f" ARCHIVO]   - Datos después decimación: ~{size_decimated_gb:.2f} GB")
+        logger.debug(f"[DEBUG ARCHIVO] TAMAÑO ESTIMADO:")
+        logger.debug(f"[DEBUG ARCHIVO]   - Datos originales: ~{size_original_gb:.2f} GB")
+        logger.debug(f"[DEBUG ARCHIVO]   - Datos después decimación: ~{size_decimated_gb:.2f} GB")
         
         
-        logger.debug(f" ARCHIVO] CONFIGURACIÓN DE SLICE:")
-        logger.debug(f" ARCHIVO]   - SLICE_DURATION_MS configurado: {config.SLICE_DURATION_MS} ms")
+        logger.debug(f"[DEBUG ARCHIVO] CONFIGURACIÓN DE SLICE:")
+        logger.debug(f"[DEBUG ARCHIVO]   - SLICE_DURATION_MS configurado: {config.SLICE_DURATION_MS} ms")
         expected_slice_len = round(config.SLICE_DURATION_MS / (config.TIME_RESO * config.DOWN_TIME_RATE * 1000))
-        logger.debug(f" ARCHIVO]   - SLICE_LEN calculado: {expected_slice_len} muestras")
-        logger.debug(f" ARCHIVO]   - SLICE_LEN límites: [{config.SLICE_LEN_MIN}, {config.SLICE_LEN_MAX}]")
+        logger.debug(f"[DEBUG ARCHIVO]   - SLICE_LEN calculado: {expected_slice_len} muestras")
+        logger.debug(f"[DEBUG ARCHIVO]   - SLICE_LEN límites: [{config.SLICE_LEN_MIN}, {config.SLICE_LEN_MAX}]")
         
-        logger.debug(f" ARCHIVO] PROCESAMIENTO:")
-        logger.debug(f" ARCHIVO]   - Multi-banda habilitado: {'SÍ' if config.USE_MULTI_BAND else 'NO'}")
-        logger.debug(f" ARCHIVO]   - DM rango: {config.DM_min} - {config.DM_max} pc cm⁻³")
-        logger.debug(f" ARCHIVO]   - Umbrales: DET_PROB={config.DET_PROB}, CLASS_PROB={config.CLASS_PROB}, SNR_THRESH={config.SNR_THRESH}")
-        logger.debug(f" ARCHIVO] " + "="*60)
+        logger.debug(f"[DEBUG ARCHIVO] PROCESAMIENTO:")
+        logger.debug(f"[DEBUG ARCHIVO]   - Multi-banda habilitado: {'SÍ' if config.USE_MULTI_BAND else 'NO'}")
+        logger.debug(f"[DEBUG ARCHIVO]   - DM rango: {config.DM_min} - {config.DM_max} pc cm⁻³")
+        logger.debug(f"[DEBUG ARCHIVO]   - Umbrales: DET_PROB={config.DET_PROB}, CLASS_PROB={config.CLASS_PROB}, SNR_THRESH={config.SNR_THRESH}")
+        logger.debug(f"[DEBUG ARCHIVO] " + "="*60)
 
                                                                                     
     auto_config_downsampling()
 
                                               
     if config.DEBUG_FREQUENCY_ORDER:
-        logger.debug(f" CONFIG FINAL] Configuración final después de get_obparams:")
-        logger.debug(f" CONFIG FINAL] " + "="*60)
-        logger.debug(f" CONFIG FINAL] DOWN_FREQ_RATE calculado: {config.DOWN_FREQ_RATE}x")
-        logger.debug(f" CONFIG FINAL] DOWN_TIME_RATE calculado: {config.DOWN_TIME_RATE}x")
-        logger.debug(f" CONFIG FINAL] Datos después de decimación:")
-        logger.debug(f" CONFIG FINAL]   - Canales: {config.FREQ_RESO // config.DOWN_FREQ_RATE}")
-        logger.debug(f" CONFIG FINAL]   - Resolución temporal: {config.TIME_RESO * config.DOWN_TIME_RATE:.2e} s/muestra")
-        logger.debug(f" CONFIG FINAL]   - Reducción total de datos: {config.DOWN_FREQ_RATE * config.DOWN_TIME_RATE}x")
-        logger.debug(f" CONFIG FINAL] DATA_NEEDS_REVERSAL final: {config.DATA_NEEDS_REVERSAL}")
-        logger.debug(f" CONFIG FINAL] Orden de frecuencias final: {'ASCENDENTE' if config.FREQ[0] < config.FREQ[-1] else 'DESCENDENTE'}")
-        logger.debug(f" CONFIG FINAL] " + "="*60)
+        logger.debug(f"[DEBUG CONFIG FINAL] Configuración final después de get_obparams:")
+        logger.debug(f"[DEBUG CONFIG FINAL] " + "="*60)
+        logger.debug(f"[DEBUG CONFIG FINAL] DOWN_FREQ_RATE calculado: {config.DOWN_FREQ_RATE}x")
+        logger.debug(f"[DEBUG CONFIG FINAL] DOWN_TIME_RATE calculado: {config.DOWN_TIME_RATE}x")
+        logger.debug(f"[DEBUG CONFIG FINAL] Datos después de decimación:")
+        logger.debug(f"[DEBUG CONFIG FINAL]   - Canales: {config.FREQ_RESO // config.DOWN_FREQ_RATE}")
+        logger.debug(f"[DEBUG CONFIG FINAL]   - Resolución temporal: {config.TIME_RESO * config.DOWN_TIME_RATE:.2e} s/muestra")
+        logger.debug(f"[DEBUG CONFIG FINAL]   - Reducción total de datos: {config.DOWN_FREQ_RATE * config.DOWN_TIME_RATE}x")
+        logger.debug(f"[DEBUG CONFIG FINAL] DATA_NEEDS_REVERSAL final: {config.DATA_NEEDS_REVERSAL}")
+        logger.debug(f"[DEBUG CONFIG FINAL] Orden de frecuencias final: {'ASCENDENTE' if config.FREQ[0] < config.FREQ[-1] else 'DESCENDENTE'}")
+        logger.debug(f"[DEBUG CONFIG FINAL] " + "="*60)
 
                                                                
     if config.DEBUG_FREQUENCY_ORDER:

--- a/src/input/utils.py
+++ b/src/input/utils.py
@@ -6,10 +6,14 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import Dict
+import logging
 
-               
+
 from ..config import config
 from ..output.summary_manager import _update_summary_with_file_debug
+
+
+logger = logging.getLogger(__name__)
 
 
 def safe_float(value, default=0.0) -> float:
@@ -55,22 +59,23 @@ def auto_config_downsampling() -> None:
 
 
 def print_debug_frequencies(prefix: str, file_name: str, freq_axis_inverted: bool) -> None:
-    """Print a standard frequency debug block with the given prefix."""
-    print(f"{prefix} File: {file_name}")
-    print(f"{prefix} Detected freq_axis_inverted: {freq_axis_inverted}")
-    print(f"{prefix} DATA_NEEDS_REVERSAL: {config.DATA_NEEDS_REVERSAL}")
-    print(f"{prefix} First 5 frequencies: {config.FREQ[:5]}")
-    print(f"{prefix} Last 5 frequencies: {config.FREQ[-5:]}")
-    print(f"{prefix} Minimum frequency: {config.FREQ.min():.2f} MHz")
-    print(f"{prefix} Maximum frequency: {config.FREQ.max():.2f} MHz")
-    print(f"{prefix} Expected order: ascending frequencies")
+    """Log a standard frequency debug block with the given prefix."""
+
+    logger.debug("%s File: %s", prefix, file_name)
+    logger.debug("%s Detected freq_axis_inverted: %s", prefix, freq_axis_inverted)
+    logger.debug("%s DATA_NEEDS_REVERSAL: %s", prefix, config.DATA_NEEDS_REVERSAL)
+    logger.debug("%s First 5 frequencies: %s", prefix, config.FREQ[:5])
+    logger.debug("%s Last 5 frequencies: %s", prefix, config.FREQ[-5:])
+    logger.debug("%s Minimum frequency: %.2f MHz", prefix, config.FREQ.min())
+    logger.debug("%s Maximum frequency: %.2f MHz", prefix, config.FREQ.max())
+    logger.debug("%s Expected order: ascending frequencies", prefix)
     if config.FREQ[0] < config.FREQ[-1]:
-        print(f"{prefix} Order CORRECT: {config.FREQ[0]:.2f} < {config.FREQ[-1]:.2f}")
+        logger.debug("%s Order CORRECT: %.2f < %.2f", prefix, config.FREQ[0], config.FREQ[-1])
     else:
-        print(f"{prefix} Order INCORRECT: {config.FREQ[0]:.2f} > {config.FREQ[-1]:.2f}")
-    print(f"{prefix} DOWN_FREQ_RATE: {config.DOWN_FREQ_RATE}")
-    print(f"{prefix} DOWN_TIME_RATE: {config.DOWN_TIME_RATE}")
-    print(f"{prefix} " + "="*50)
+        logger.debug("%s Order INCORRECT: %.2f > %.2f", prefix, config.FREQ[0], config.FREQ[-1])
+    logger.debug("%s DOWN_FREQ_RATE: %s", prefix, config.DOWN_FREQ_RATE)
+    logger.debug("%s DOWN_TIME_RATE: %s", prefix, config.DOWN_TIME_RATE)
+    logger.debug("%s %s", prefix, "=" * 50)
 
 
 def save_file_debug_info(file_name: str, debug_info: Dict) -> None:
@@ -81,4 +86,4 @@ def save_file_debug_info(file_name: str, debug_info: Dict) -> None:
         filename = Path(file_name).stem
         _update_summary_with_file_debug(results_dir, filename, debug_info)
     except Exception as e:
-        print(f"[WARNING] Error saving debug info for {file_name}: {e}")
+        logger.warning("Failed to save debug info for %s: %s", file_name, e)

--- a/src/logging/chunking_logging.py
+++ b/src/logging/chunking_logging.py
@@ -16,107 +16,76 @@ from .logging_config import get_global_logger
 
 
 def display_detailed_chunking_info(parameters: Dict[str, Any]) -> None:
-    """
-    Muestra información detallada del sistema de chunking en consola.
-    
-    Args:
-        parameters: Diccionario con parámetros de procesamiento calculados
-    """
-    logger = get_global_logger()
-    
-    logger.logger.info("=" * 80)
-    logger.logger.info("SISTEMA DE CHUNKING DETALLADO")
-    logger.logger.info("=" * 80)
-    
-                                                                                   
-                            
-                                                                                   
-    logger.logger.info("PARÁMETROS DEL USUARIO:")
-    logger.logger.info(f"   • Duración deseada de slice: {parameters['slice_duration_ms_target']:.1f} ms")
-    logger.logger.info(f"   • Factor de downsampling temporal: {parameters['down_time_rate']}x")
-    logger.logger.info(f"   • Factor de downsampling frecuencial: {parameters['down_freq_rate']}x")
-    
-                                                                                   
-                                     
-                                                                                   
-    logger.logger.info("PARÁMETROS DEL ARCHIVO ORIGINAL:")
-    logger.logger.info(f"   • Muestras totales: {parameters['total_samples_original']:,}")
-    logger.logger.info(f"   • Canales totales: {parameters['total_channels_original']:,}")
-    logger.logger.info(f"   • Resolución temporal: {parameters['time_reso_original']:.2e} s")
-    logger.logger.info(f"   • Duración total: {parameters['total_duration_min']:.1f} min ({parameters['total_duration_sec']:.1f} s)")
-    
-                                                                                   
-                                         
-                                                                                   
-    logger.logger.info("PARÁMETROS DESPUÉS DEL DOWNSAMPLING:")
-    logger.logger.info(f"   • Muestras con downsampling: {parameters['total_samples_downsampled']:,}")
-    logger.logger.info(f"   • Canales con downsampling: {parameters['total_channels_downsampled']:,}")
-    logger.logger.info(f"   • Resolución temporal: {parameters['time_reso_downsampled']:.2e} s")
-    
-                                                                                   
-                           
-                                                                                   
-    logger.logger.info("PARÁMETROS CALCULADOS (previos y alineados a streaming):")
-    logger.logger.info(f"   • Muestras por slice (decimado): {parameters['samples_per_slice']:,}")
-    logger.logger.info(f"   • Muestras por chunk (decimado teórico): {parameters['chunk_samples']:,}")
-    logger.logger.info(f"   • Muestras por chunk (original para streaming): {parameters.get('chunk_samples_stream_original', 0):,}")
-    logger.logger.info(f"   • Muestras por chunk (decimado efectivo en streaming): {parameters.get('chunk_samples_stream_decimated', 0):,}")
-    logger.logger.info(f"   • Slices por chunk (preview teórico): {parameters['slices_per_chunk']}")
-    logger.logger.info(f"   • Slices por chunk (preview alineado a streaming): {parameters.get('slices_per_chunk_stream_estimate', 0)}")
-    logger.logger.info(f"   • Duración de chunk (teórica, decimado): {parameters['chunk_duration_sec']:.3f} s")
-    logger.logger.info(f"   • Duración de chunk (streaming, original): {parameters.get('chunk_duration_stream_sec', 0.0):.3f} s")
-    logger.logger.info(f"   • Total de chunks (estimado): {parameters['total_chunks']}")
-    logger.logger.info(f"   • Total de slices (global): {parameters['total_slices']:,}")
-    logger.logger.info("Nota: El planificador por chunk imprimirá el número real por chunk en ejecución.")
-    
-                                                                                   
-                
-                                                                                   
-    logger.logger.info("DURACIONES:")
-    logger.logger.info(f"   • Duración real de slice: {parameters['slice_duration_ms_real']:.1f} ms")
-    logger.logger.info(f"   • Duración de chunk: {parameters['chunk_duration_sec']:.1f} s")
-    
-                                                                                   
-                            
-                                                                                   
-    logger.logger.info("INFORMACIÓN DE MEMORIA:")
-    logger.logger.info(f"   • Tamaño del archivo: {parameters['total_file_size_gb']:.2f} GB")
-    logger.logger.info(f"   • Tamaño por chunk: {parameters['chunk_size_gb']:.2f} GB")
-    logger.logger.info(f"   • Memoria disponible: {parameters['available_memory_gb']:.1f} GB")
-    logger.logger.info(f"   • Memoria total: {parameters['total_memory_gb']:.1f} GB")
-    logger.logger.info(f"   • ¿Puede cargar archivo completo?: {'Sí' if parameters['can_load_full_file'] else 'No'}")
-    
-                                                                                   
-                        
-                                                                                   
-    logger.logger.info("ESTADO DEL SISTEMA:")
-    logger.logger.info(f"   • Modo optimizado de memoria: {'Activado' if parameters['memory_optimized'] else 'Desactivado'}")
-    
-                                                                                   
-                         
-                                                                                   
-    if parameters['has_leftover_samples']:
-        leftover_time_ms = parameters['leftover_samples'] * parameters['time_reso_downsampled'] * 1000
-        logger.logger.warning("ADVERTENCIA - MUESTRAS RESIDUALES:")
-        logger.logger.warning(f"   • Muestras sobrantes en el último chunk: {parameters['leftover_samples']:,}")
-        logger.logger.warning(f"   • Tiempo sobrante: {leftover_time_ms:.1f} ms")
-        logger.logger.warning(f"   • Estas muestras NO formarán un slice completo")
-    
-    logger.logger.info("=" * 80)
+    """Emit a concise overview of the chunking plan."""
+
+    logger = get_global_logger().logger
+
+    logger.info(
+        "Chunking overview • target_slice=%.1f ms (%d samples) • downsample t=%dx f=%dx",
+        parameters["slice_duration_ms_target"],
+        parameters["samples_per_slice"],
+        parameters["down_time_rate"],
+        parameters["down_freq_rate"],
+    )
+
+    logger.info(
+        "Input data • samples=%s • channels=%d • duration=%.1fs (%.1f min)",
+        f"{parameters['total_samples_original']:,}",
+        parameters["total_channels_original"],
+        parameters["total_duration_sec"],
+        parameters["total_duration_min"],
+    )
+
+    logger.info(
+        "After downsampling • samples=%s • channels=%d • Δt=%.3f ms • slices/chunk≈%d",
+        f"{parameters['total_samples_downsampled']:,}",
+        parameters["total_channels_downsampled"],
+        parameters["time_reso_downsampled"] * 1e3,
+        parameters["slices_per_chunk"],
+    )
+
+    logger.info(
+        "Chunks • size=%s samples (~%.1fs) • estimated=%d chunks • total_slices=%d",
+        f"{parameters['chunk_samples']:,}",
+        parameters["chunk_duration_sec"],
+        parameters["total_chunks"],
+        parameters["total_slices"],
+    )
+
+    logger.info(
+        "Memory • file=%.2f GB • chunk=%.2f GB • available=%.1f/%.1f GB • optimized=%s",
+        parameters["total_file_size_gb"],
+        parameters["chunk_size_gb"],
+        parameters["available_memory_gb"],
+        parameters["total_memory_gb"],
+        "yes" if parameters["memory_optimized"] else "no",
+    )
+
+    if parameters["has_leftover_samples"]:
+        leftover_time_ms = parameters["leftover_samples"] * parameters["time_reso_downsampled"] * 1000
+        logger.warning(
+            "Residual samples • %s (~%.1f ms) will be skipped",
+            f"{parameters['leftover_samples']:,}",
+            leftover_time_ms,
+        )
 
 
 def log_chunk_processing_start(chunk_idx: int, chunk_info: Dict[str, Any]) -> None:
     """
     Registra el inicio del procesamiento de un chunk.
-    
+
     Args:
         chunk_idx: Índice del chunk
         chunk_info: Información del chunk
     """
-    logger = get_global_logger()
-    logger.logger.info(f"Iniciando procesamiento del chunk {chunk_idx:03d}/{chunk_info.get('total_chunks', 0)}")
-    logger.logger.info(f"   • Muestras en chunk: {chunk_info.get('chunk_samples', 0):,}")
-    logger.logger.info(f"   • Slices en chunk: {chunk_info.get('slices_per_chunk', 0)}")
+    logger = get_global_logger().logger
+    logger.info(
+        "Chunk %03d/%03d • samples=%s • slices=%d",
+        chunk_idx,
+        chunk_info.get("total_chunks", 0),
+        f"{chunk_info.get('chunk_samples', 0):,}",
+        chunk_info.get("slices_per_chunk", 0),
+    )
 
 
 def log_chunk_processing_end(chunk_idx: int, results: Dict[str, Any]) -> None:
@@ -127,10 +96,13 @@ def log_chunk_processing_end(chunk_idx: int, results: Dict[str, Any]) -> None:
         chunk_idx: Índice del chunk
         results: Resultados del procesamiento
     """
-    logger = get_global_logger()
-    logger.logger.info(f"Chunk {chunk_idx:03d} procesado exitosamente")
-    logger.logger.info(f"   • Candidatos encontrados: {results.get('candidates', 0)}")
-    logger.logger.info(f"   • Tiempo de procesamiento: {results.get('processing_time', 0):.2f} s")
+    logger = get_global_logger().logger
+    logger.info(
+        "Chunk %03d finished • candidates=%d • runtime=%.2fs",
+        chunk_idx,
+        results.get("candidates", 0),
+        results.get("processing_time", 0.0),
+    )
 
 
 def log_file_processing_summary(file_info: Dict[str, Any]) -> None:
@@ -140,13 +112,15 @@ def log_file_processing_summary(file_info: Dict[str, Any]) -> None:
     Args:
         file_info: Información del archivo procesado
     """
-    logger = get_global_logger()
-    logger.logger.info("RESUMEN DEL PROCESAMIENTO:")
-    logger.logger.info(f"   • Archivo: {file_info.get('filename', 'N/A')}")
-    logger.logger.info(f"   • Chunks procesados: {file_info.get('total_chunks', 0)}")
-    logger.logger.info(f"   • Slices procesados: {file_info.get('total_slices', 0):,}")
-    logger.logger.info(f"   • Candidatos totales: {file_info.get('total_candidates', 0)}")
-    logger.logger.info(f"   • Tiempo total: {file_info.get('total_time', 0):.2f} s")
+    logger = get_global_logger().logger
+    logger.info(
+        "File summary • %s • chunks=%d • slices=%s • candidates=%d • runtime=%.2fs",
+        file_info.get("filename", "N/A"),
+        file_info.get("total_chunks", 0),
+        f"{file_info.get('total_slices', 0):,}",
+        file_info.get("total_candidates", 0),
+        file_info.get("total_time", 0.0),
+    )
 
 
 def log_memory_optimization(optimization_info: Dict[str, Any]) -> None:
@@ -156,11 +130,13 @@ def log_memory_optimization(optimization_info: Dict[str, Any]) -> None:
     Args:
         optimization_info: Información de optimización
     """
-    logger = get_global_logger()
-    logger.logger.info("OPTIMIZACIÓN DE MEMORIA:")
-    logger.logger.info(f"   • Estrategia: {optimization_info.get('strategy', 'N/A')}")
-    logger.logger.info(f"   • Memoria utilizada: {optimization_info.get('memory_used_gb', 0):.2f} GB")
-    logger.logger.info(f"   • Eficiencia: {optimization_info.get('efficiency_percent', 0):.1f}%")
+    logger = get_global_logger().logger
+    logger.debug(
+        "Memory optimisation • strategy=%s • used=%.2f GB • efficiency=%.1f%%",
+        optimization_info.get("strategy", "N/A"),
+        optimization_info.get("memory_used_gb", 0.0),
+        optimization_info.get("efficiency_percent", 0.0),
+    )
 
 
 def log_slice_configuration(slice_config: Dict[str, Any]) -> None:
@@ -170,18 +146,20 @@ def log_slice_configuration(slice_config: Dict[str, Any]) -> None:
     Args:
         slice_config: Configuración de slices
     """
-    logger = get_global_logger()
-    logger.logger.info("CONFIGURACIÓN DE SLICES:")
-    logger.logger.info(f"   • Duración objetivo: {slice_config.get('target_duration_ms', 0):.1f} ms")
-    logger.logger.info(f"   • Muestras por slice: {slice_config.get('samples_per_slice', 0):,}")
-    logger.logger.info(f"   • Duración real: {slice_config.get('real_duration_ms', 0):.1f} ms")
-    logger.logger.info(f"   • Precisión: {slice_config.get('precision_percent', 0):.1f}%")
+    logger = get_global_logger().logger
+    logger.info(
+        "Slice configuration • target=%.1f ms • samples=%s • actual=%.1f ms • accuracy=%.1f%%",
+        slice_config.get("target_duration_ms", 0.0),
+        f"{slice_config.get('samples_per_slice', 0):,}",
+        slice_config.get("real_duration_ms", 0.0),
+        slice_config.get("precision_percent", 0.0),
+    )
 
 
 def log_chunk_budget(budget: Dict[str, Any]) -> None:
     """
     Registra el presupuesto de memoria y cálculo de tamaño de chunk cuando el planificador está activo.
-    
+
     Args:
         budget: Dict con llaves esperadas:
             - bytes_per_sample
@@ -194,16 +172,17 @@ def log_chunk_budget(budget: Dict[str, Any]) -> None:
             - down_time_rate
             - down_freq_rate
     """
-    logger = get_global_logger()
-    logger.logger.info("PRESUPUESTO DE CHUNKING (planificador)")
-    logger.logger.info(f"   • Bytes por muestra: {budget.get('bytes_per_sample', 0):,}")
-    logger.logger.info(f"   • Memoria disponible: {budget.get('available_bytes', 0) / (1024**3):.2f} GB")
-    logger.logger.info(f"   • Usable tras overhead: {budget.get('usable_bytes', 0) / (1024**3):.2f} GB")
-    logger.logger.info(f"   • nsamp_max (raw): {budget.get('nsamp_max_raw', 0):,}")
-    logger.logger.info(f"   • nsamp_max alineado a slice_len: {budget.get('nsamp_max_aligned', 0):,}")
-    logger.logger.info(f"   • slice_len: {budget.get('slice_len', 0):,} muestras")
-    logger.logger.info(f"   • chunk_samples final: {budget.get('chunk_samples', 0):,} muestras")
-    logger.logger.info(f"   • Downsampling: tiempo={budget.get('down_time_rate', 1)}x, freq={budget.get('down_freq_rate', 1)}x")
+    logger = get_global_logger().logger
+    logger.info(
+        "Chunk budget • bytes/sample=%s • usable=%.2f/%.2f GB • nsamp_max=%s → chunk=%s • downsample t=%dx f=%dx",
+        f"{budget.get('bytes_per_sample', 0):,}",
+        budget.get('usable_bytes', 0) / (1024 ** 3),
+        budget.get('available_bytes', 0) / (1024 ** 3),
+        f"{budget.get('nsamp_max_aligned', 0):,}",
+        f"{budget.get('chunk_samples', 0):,}",
+        budget.get('down_time_rate', 1),
+        budget.get('down_freq_rate', 1),
+    )
 
 
 def log_slice_plan_summary(chunk_idx: int, plan: Dict[str, Any]) -> None:
@@ -211,24 +190,38 @@ def log_slice_plan_summary(chunk_idx: int, plan: Dict[str, Any]) -> None:
 
     Muestra número de slices, duración media y algunos ejemplos de límites.
     """
-    logger = get_global_logger()
+    logger = get_global_logger().logger
     n = plan.get("n_slices", 0)
     avg_ms = plan.get("avg_ms", 0.0)
     delta_ms = plan.get("delta_ms", 0.0)
     slices = plan.get("slices", [])
-    logger.logger.info(f"PLAN DE SLICES (chunk {chunk_idx:03d})")
-    logger.logger.info(f"   • n_slices: {n}")
-    logger.logger.info(f"   • duración media por slice: {avg_ms:.6f} ms (Δ={delta_ms:+.6f} ms respecto a objetivo)")
+
     if slices:
         lengths = [sl.length for sl in slices]
-        logger.logger.info(f"   • tamaño de slice (muestras): min={min(lengths)}, max={max(lengths)}, mediana={sorted(lengths)[len(lengths)//2]}")
-                                                       
-        preview = []
-        for idx in [0, 1, len(slices) - 1]:
-            if 0 <= idx < len(slices):
-                sl = slices[idx]
-                preview.append(f"[{idx:04d}] {sl.start_idx}→{sl.end_idx} ({sl.length} muestras, {sl.duration_ms:.6f} ms)")
-        if preview:
-            logger.logger.info("   • ejemplos: ")
-            for line in preview:
-                logger.logger.info(f"      {line}")
+        min_len = min(lengths)
+        max_len = max(lengths)
+        median_len = sorted(lengths)[len(lengths) // 2]
+    else:
+        min_len = max_len = median_len = 0
+
+    logger.info(
+        "Slice plan • chunk=%03d • count=%d • avg=%.3f ms (Δ=%.3f ms) • length[min/median/max]=%d/%d/%d",
+        chunk_idx,
+        n,
+        avg_ms,
+        delta_ms,
+        min_len,
+        median_len,
+        max_len,
+    )
+
+    if slices:
+        preview_indices = [idx for idx in (0, 1, len(slices) - 1) if 0 <= idx < len(slices)]
+        preview_lines = []
+        for idx in preview_indices:
+            sl = slices[idx]
+            preview_lines.append(
+                f"[{idx:04d}] {sl.start_idx}→{sl.end_idx} ({sl.length} samples, {sl.duration_ms:.3f} ms)"
+            )
+        if preview_lines:
+            logger.debug("Slice plan preview • %s", " | ".join(preview_lines))

--- a/src/logging/logging_config.py
+++ b/src/logging/logging_config.py
@@ -98,158 +98,236 @@ class DRAFTSFormatter(logging.Formatter):
 
 
 class DRAFTSLogger:
-    """Logger principal para DRAFTS con funcionalidades especializadas."""
-    
-    def __init__(self, name: str = "DRAFTS", level: str = "INFO", 
+    """Central logger used across the DRAFTS pipeline."""
+
+    def __init__(self, name: str = "DRAFTS", level: str = "INFO",
                  log_file: Optional[Path] = None, use_colors: bool = True):
         self.logger = logging.getLogger(name)
         self.logger.setLevel(getattr(logging, level.upper()))
-        
-                                        
+
         if self.logger.handlers:
+            self.logger.propagate = False
             return
-        
-                              
+
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setFormatter(DRAFTSFormatter(use_colors))
-        self.logger.addHandler(console_handler)
-        
-                                                               
+
         if log_file is None:
-                                                                     
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             log_dir = Path(__file__).parent / "log"
             log_file = log_dir / f"drafts_pipeline_{timestamp}.log"
-        
-                                                              
+
         log_file.parent.mkdir(parents=True, exist_ok=True)
-        file_handler = logging.FileHandler(log_file, encoding='utf-8')
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
         file_handler.setFormatter(DRAFTSFormatter(use_colors=False))
+
+        self.logger.addHandler(console_handler)
         self.logger.addHandler(file_handler)
-        
-                                       
-        self.logger.info(f"Logs guardándose en: {log_file.absolute()}")
-    
-    def pipeline_start(self, config: Dict[str, Any]):
-        """Log del inicio del pipeline."""
-        self.logger.info(f"{Colors.PIPELINE}INICIANDO PIPELINE DE DETECCIÓN DE FRB{Colors.ENDC}")
-        
-                                                     
-        self.logger.info(f"{Colors.OKBLUE}Leyenda de Colores:{Colors.ENDC}")
-        self.logger.info(f"{Colors.PIPELINE} Pipeline: Operaciones principales del pipeline{Colors.ENDC}")
-        self.logger.info(f"{Colors.FILE} Archivos: Procesamiento de archivos{Colors.ENDC}")
-        self.logger.info(f"{Colors.PROCESSING} Procesamiento: Chunks y Slices{Colors.ENDC}")
-        self.logger.info(f"{Colors.DETECTION} Detección: Candidatos detectados{Colors.ENDC}")
-        self.logger.info(f"{Colors.GPU} GPU: Operaciones de GPU{Colors.ENDC}")
-        self.logger.info(f"{Colors.WARNING} Advertencia: Problemas no críticos{Colors.ENDC}")
-        self.logger.info(f"{Colors.ERROR} Error: Fallos críticos{Colors.ENDC}")
-        self.logger.info(f"{Colors.OKCYAN} Debug: Información detallada (solo en modo DEBUG){Colors.ENDC}")
-        self.logger.info("")                                  
-        
-        self.logger.info(f"Datos: {config.get('data_dir', 'N/A')}")
-        self.logger.info(f"Resultados: {config.get('results_dir', 'N/A')}")
-        self.logger.info(f"Targets: {config.get('targets', [])}")
-        if config.get('chunk_samples', 0) > 0:
-            self.logger.info(f"Chunking: {config['chunk_samples']:,} muestras/bloque")
-    
-    def pipeline_end(self, summary: Dict[str, Any]):
-        """Log del fin del pipeline."""
+        self.logger.propagate = False
+
+        root_logger = logging.getLogger()
+        root_logger.setLevel(self.logger.level)
+        root_logger.handlers.clear()
+        root_logger.addHandler(console_handler)
+        root_logger.addHandler(file_handler)
+
+        self.logger.info("Logs stored in: %s", log_file.absolute())
+
+    def pipeline_start(self, config: Dict[str, Any]) -> None:
+        """Emit a concise summary when the pipeline starts."""
+
+        self.logger.info("Starting FRB detection pipeline")
+        self.logger.info(
+            "Paths • data=%s • results=%s",
+            config.get("data_dir", "N/A"),
+            config.get("results_dir", "N/A"),
+        )
+        targets = config.get("targets", [])
+        if targets:
+            self.logger.info("Targets • %s", ", ".join(map(str, targets)))
+        chunk_samples = config.get("chunk_samples", 0)
+        if chunk_samples:
+            self.logger.info("Chunk override • %s samples", f"{chunk_samples:,}")
+
+    def pipeline_end(self, summary: Dict[str, Any]) -> None:
+        """Log a compact summary of the pipeline execution."""
+
         total_files = len(summary)
-        total_candidates = sum(r.get('n_candidates', 0) for r in summary.values())
-        total_bursts = sum(r.get('n_bursts', 0) for r in summary.values())
-        total_time = sum(r.get('runtime_s', 0) for r in summary.values())
-        
-        self.logger.info(f"{Colors.PIPELINE} PIPELINE COMPLETADO{Colors.ENDC}")
-        self.logger.info(f"Resumen: {total_files} archivos, {total_candidates} candidatos, {total_bursts} bursts")
-        self.logger.info(f"Tiempo total: {total_time:.1f}s")
-    
-    def file_processing_start(self, filename: str, file_info: Dict[str, Any]):
-        """Log del inicio de procesamiento de archivo."""
-        self.logger.info(f"{Colors.FILE} Procesando: {filename}{Colors.ENDC}")
-        self.logger.info(f"Muestras: {file_info.get('samples', 0):,}")
-        self.logger.info(f"Duración: {file_info.get('duration_min', 0):.1f} min")
-        self.logger.info(f"Canales: {file_info.get('channels', 0)}")
-    
-    def file_processing_end(self, filename: str, results: Dict[str, Any]):
-        """Log del fin de procesamiento de archivo."""
-        self.logger.info(f"{Colors.FILE} {filename}: {results.get('n_candidates', 0)} candidatos, "
-                        f"max prob {results.get('max_prob', 0):.2f}, "
-                        f"{results.get('runtime_s', 0):.1f}s{Colors.ENDC}")
-    
-    def chunk_processing(self, chunk_idx: int, chunk_info: Dict[str, Any]):
-        """Log del procesamiento de chunk."""
-        self.logger.info(f"{Colors.PROCESSING} Chunk {chunk_idx:03d}: "
-                        f"{chunk_info.get('samples', 0):,} muestras → "
-                        f"{chunk_info.get('slices', 0)} slices{Colors.ENDC}")
-    
-    def slice_processing(self, slice_idx: int, slice_info: Dict[str, Any]):
-        """Log del procesamiento de slice."""
-        candidates = slice_info.get('candidates', 0)
+        total_candidates = sum(r.get("n_candidates", 0) for r in summary.values())
+        total_bursts = sum(r.get("n_bursts", 0) for r in summary.values())
+        total_time = sum(r.get("runtime_s", 0.0) for r in summary.values())
+
+        self.logger.info("Pipeline finished")
+        self.logger.info(
+            "Summary • files=%d • candidates=%d • bursts=%d • runtime=%.1fs",
+            total_files,
+            total_candidates,
+            total_bursts,
+            total_time,
+        )
+
+    def file_processing_start(self, filename: str, file_info: Dict[str, Any]) -> None:
+        """Log that a new file is being processed."""
+
+        self.logger.info(
+            "Processing file • %s • samples=%s • duration=%.1f min • channels=%d",
+            filename,
+            f"{file_info.get('samples', 0):,}",
+            file_info.get("duration_min", 0.0),
+            file_info.get("channels", 0),
+        )
+
+    def file_processing_end(self, filename: str, results: Dict[str, Any]) -> None:
+        """Log the result obtained after processing a file."""
+
+        self.logger.info(
+            "File result • %s • candidates=%d • bursts=%d • max_prob=%.2f • runtime=%.1fs",
+            filename,
+            results.get("n_candidates", 0),
+            results.get("n_bursts", 0),
+            results.get("max_prob", 0.0),
+            results.get("runtime_s", 0.0),
+        )
+
+    def chunk_processing(self, chunk_idx: int, chunk_info: Dict[str, Any]) -> None:
+        """Log a high-level summary for a chunk."""
+
+        self.logger.info(
+            "Chunk %03d • samples=%s • slices=%d",
+            chunk_idx,
+            f"{chunk_info.get('samples', 0):,}",
+            chunk_info.get("slices", 0),
+        )
+
+    def slice_processing(self, slice_idx: int, slice_info: Dict[str, Any]) -> None:
+        """Log slice information only when something relevant happened."""
+
+        candidates = slice_info.get("candidates", 0)
         if candidates > 0:
-            self.logger.info(f"{Colors.DETECTION}Slice {slice_idx}: {candidates} candidatos detectados{Colors.ENDC}")
-    
-    def gpu_info(self, message: str, level: str = "INFO"):
-        """Log de información GPU."""
-        if level.upper() == "INFO":
-            self.logger.info(f"{Colors.GPU} {message}{Colors.ENDC}")
-        elif level.upper() == "DEBUG":
-            self.logger.debug(f"{Colors.GPU} {message}{Colors.ENDC}")
-    
-    def debug_file_info(self, file_info: Dict[str, Any]):
-        """Log de información detallada de archivo (solo en DEBUG)."""
-        self.logger.debug(f"Información del archivo:")
-        self.logger.debug(f"   - Resolución temporal: {file_info.get('time_reso', 0):.2e} s")
-        self.logger.debug(f"   - Resolución frecuencia: {file_info.get('freq_reso', 0)} canales")
-        self.logger.debug(f"   - Frecuencia inicial: {file_info.get('freq_start', 0):.1f} MHz")
-        self.logger.debug(f"   - Ancho de banda: {file_info.get('bandwidth', 0):.1f} MHz")
-    
-    def slice_config(self, config_info: Dict[str, Any]):
-        """Log de configuración de slice."""
-        self.logger.info(f"Configuración de slice:")
-        self.logger.info(f"Duración objetivo: {config_info.get('target_ms', 0):.1f} ms")
-        self.logger.info(f"SLICE_LEN: {config_info.get('slice_len', 0)} muestras")
-        self.logger.info(f"Duración real: {config_info.get('real_ms', 0):.1f} ms")
-    
-    def slice_progress(self, current_slice: int, total_slices: int, chunk_idx: Optional[int] = None):
-        """Log de progreso de slices."""
-        percentage = (current_slice / total_slices) * 100 if total_slices > 0 else 0
-        chunk_info = f" (chunk {chunk_idx:03d})" if chunk_idx is not None else ""
-        self.logger.info(f"{Colors.PROCESSING} Progreso: slice {current_slice:03d}/{total_slices-1:03d} ({percentage:.1f}%){chunk_info}{Colors.ENDC}")
-    
-    def candidate_detected(self, dm: float, time: float, confidence: float, class_prob: float, is_burst: bool, snr_raw: float, snr_patch: float):
-        """Log de candidato detectado."""
-        burst_status = "BURST" if is_burst else "NO burst"
-        self.logger.info(f"{Colors.DETECTION} Candidato encontrado: DM={dm:.1f} t={time:.3f}s conf={confidence:.2f} class={class_prob:.2f} → {burst_status}{Colors.ENDC}")
-        self.logger.info(f"{Colors.OKCYAN} SNR Raw: {snr_raw:.2f}σ, SNR Patch: {snr_patch:.2f}σ{Colors.ENDC}")
-    
-    def slice_completed(self, slice_idx: int, candidates: int, bursts: int, no_bursts: int):
-        """Log de slice completado."""
-        if candidates > 0:
-            self.logger.info(f"{Colors.DETECTION} Slice {slice_idx:03d} completado: {candidates} candidatos ({bursts} bursts, {no_bursts} no bursts){Colors.ENDC}")
-    
-    def chunk_completed(self, chunk_idx: int, total_candidates: int, total_bursts: int, total_no_bursts: int):
-        """Log de chunk completado."""
-        self.logger.info(f"{Colors.PROCESSING} Chunk {chunk_idx:03d} completado: {total_candidates} candidatos totales ({total_bursts} bursts, {total_no_bursts} no bursts){Colors.ENDC}")
-    
-    def processing_band(self, band_name: str, slice_idx: int):
-        """Log de procesamiento de banda."""
-        self.logger.info(f"{Colors.PROCESSING} Procesando {band_name} (slice {slice_idx}){Colors.ENDC}")
-    
-    def band_candidates(self, band_name: str, candidate_count: int):
-        """Log de candidatos por banda."""
-        if candidate_count > 0:
-            self.logger.info(f"{Colors.DETECTION} {band_name}: {candidate_count} candidatos detectados{Colors.ENDC}")
+            bursts = slice_info.get("bursts", 0)
+            no_bursts = slice_info.get("no_bursts", candidates - bursts)
+            self.logger.info(
+                "Slice %03d • candidates=%d (bursts=%d • non-bursts=%d)",
+                slice_idx,
+                candidates,
+                bursts,
+                no_bursts,
+            )
+
+    def gpu_info(self, message: str, level: str = "INFO") -> None:
+        """Log GPU related messages respecting their level."""
+
+        if level.upper() == "DEBUG":
+            self.logger.debug(message)
         else:
-            self.logger.debug(f"{Colors.OKCYAN} {band_name}: Sin candidatos detectados{Colors.ENDC}")
-    
-    def creating_waterfall(self, waterfall_type: str, slice_idx: int, dm: Optional[float] = None):
-        """Log de creación de waterfall."""
+            self.logger.info(message)
+
+    def debug_file_info(self, file_info: Dict[str, Any]) -> None:
+        """Emit a compact debug line with file metadata."""
+
+        self.logger.debug(
+            "File info • Δt=%0.2e s • channels=%d • f_start=%.1f MHz • bandwidth=%.1f MHz",
+            file_info.get("time_reso", 0.0),
+            file_info.get("freq_reso", 0),
+            file_info.get("freq_start", 0.0),
+            file_info.get("bandwidth", 0.0),
+        )
+
+    def slice_config(self, config_info: Dict[str, Any]) -> None:
+        """Log the slice configuration in a single line."""
+
+        self.logger.info(
+            "Slice configuration • target=%.1f ms • length=%d samples • actual=%.1f ms",
+            config_info.get("target_ms", 0.0),
+            config_info.get("slice_len", 0),
+            config_info.get("real_ms", 0.0),
+        )
+
+    def slice_progress(self, current_slice: int, total_slices: int,
+                       chunk_idx: Optional[int] = None) -> None:
+        """Emit slice progress at debug level to avoid flooding the console."""
+
+        percentage = (current_slice / total_slices) * 100 if total_slices else 0.0
+        chunk_info = f"chunk {chunk_idx:03d}" if chunk_idx is not None else "pipeline"
+        self.logger.debug(
+            "Slice progress • %s • %03d/%03d (%.1f%%)",
+            chunk_info,
+            current_slice,
+            max(total_slices - 1, 0),
+            percentage,
+        )
+
+    def candidate_detected(self, dm: float, time: float, confidence: float,
+                           class_prob: float, is_burst: bool, snr_raw: float,
+                           snr_patch: float) -> None:
+        """Log a candidate detection event."""
+
+        burst_status = "burst" if is_burst else "noise"
+        self.logger.info(
+            "Candidate • DM=%.1f • t=%.3fs • detect=%.2f • class=%.2f • SNR(raw=%.2f, patch=%.2f) • %s",
+            dm,
+            time,
+            confidence,
+            class_prob,
+            snr_raw,
+            snr_patch,
+            burst_status,
+        )
+
+    def slice_completed(self, slice_idx: int, candidates: int, bursts: int,
+                        no_bursts: int) -> None:
+        """Log aggregate information after finishing a slice."""
+
+        if candidates > 0:
+            self.logger.info(
+                "Slice %03d complete • candidates=%d (bursts=%d • non-bursts=%d)",
+                slice_idx,
+                candidates,
+                bursts,
+                no_bursts,
+            )
+
+    def chunk_completed(self, chunk_idx: int, total_candidates: int,
+                        total_bursts: int, total_no_bursts: int) -> None:
+        """Log the summary for a completed chunk."""
+
+        self.logger.info(
+            "Chunk %03d complete • candidates=%d (bursts=%d • non-bursts=%d)",
+            chunk_idx,
+            total_candidates,
+            total_bursts,
+            total_no_bursts,
+        )
+
+    def processing_band(self, band_name: str, slice_idx: int) -> None:
+        """Debug log for per-band processing steps."""
+
+        self.logger.debug("Processing %s for slice %d", band_name, slice_idx)
+
+    def band_candidates(self, band_name: str, candidate_count: int) -> None:
+        """Log band statistics when candidates are found."""
+
+        if candidate_count > 0:
+            self.logger.info("%s • %d candidates", band_name, candidate_count)
+        else:
+            self.logger.debug("%s • no candidates", band_name)
+
+    def creating_waterfall(self, waterfall_type: str, slice_idx: int,
+                           dm: Optional[float] = None) -> None:
+        """Debug log when generating waterfall plots."""
+
         dm_info = f" (DM={dm:.1f})" if dm is not None else ""
-        self.logger.debug(f"{Colors.OKCYAN} Creando waterfall {waterfall_type} para slice {slice_idx}{dm_info}{Colors.ENDC}")
-    
-    def generating_plots(self):
-        """Log de generación de plots."""
-        self.logger.debug(f"{Colors.OKCYAN} Generando plots compuestos y de detección{Colors.ENDC}")
+        self.logger.debug(
+            "Creating %s waterfall for slice %d%s",
+            waterfall_type,
+            slice_idx,
+            dm_info,
+        )
+
+    def generating_plots(self) -> None:
+        """Debug log used when building plots."""
+
+        self.logger.debug("Generating composite and detection plots")
 
 
 def setup_logging(level: str = "INFO", log_file: Optional[Path] = None, 

--- a/src/logging/pipeline_logging.py
+++ b/src/logging/pipeline_logging.py
@@ -30,10 +30,16 @@ def log_streaming_parameters(effective_chunk_samples: int, overlap_raw: int,
         streaming_func: Función de streaming utilizada
         file_type: Tipo de archivo detectado
     """
-    logger = get_global_logger()
-    logger.logger.debug(f"[DEBUG] DEBUG STREAMING: effective_chunk_samples={effective_chunk_samples:,}, overlap_raw={overlap_raw}")
-    logger.logger.debug(f"[DEBUG] DEBUG STREAMING: total_samples={total_samples:,}, chunk_samples={chunk_samples:,}")
-    logger.logger.debug(f"[DEBUG] DEBUG STREAMING: streaming_func={getattr(streaming_func, '__name__', str(streaming_func))}, file_type={file_type}")
+    logger = get_global_logger().logger
+    logger.info(
+        "Streaming • type=%s • reader=%s • chunk=%s (effective=%s) • overlap=%d • total=%s",
+        file_type,
+        getattr(streaming_func, "__name__", str(streaming_func)),
+        f"{chunk_samples:,}",
+        f"{effective_chunk_samples:,}",
+        overlap_raw,
+        f"{total_samples:,}",
+    )
 
 
 def log_block_processing(actual_chunk_count: int, block_shape: tuple, block_dtype: str,
@@ -47,16 +53,15 @@ def log_block_processing(actual_chunk_count: int, block_shape: tuple, block_dtyp
         block_dtype: Tipo de datos del bloque
         metadata: Metadatos del bloque
     """
-    logger = get_global_logger()
-    logger.logger.debug(f"[DEBUG] DEBUG BLOQUE {actual_chunk_count}: shape={block_shape}, dtype={block_dtype}")
-    # Evitar problemas de serialización JSON con metadatos complejos
-    metadata_str = str(metadata) if metadata else "None"
-    logger.logger.debug(f"[DEBUG] DEBUG BLOQUE {actual_chunk_count}: metadata={metadata_str}")
-    logger.logger.debug(f"[DEBUG] DEBUG BLOQUE {actual_chunk_count}: chunk_idx={metadata.get('chunk_idx', 'N/A')}")
-    logger.logger.debug(f"[DEBUG] DEBUG BLOQUE {actual_chunk_count}: start_sample={metadata.get('start_sample', 'N/A'):,}")
-    logger.logger.debug(f"[DEBUG] DEBUG BLOQUE {actual_chunk_count}: end_sample={metadata.get('end_sample', 'N/A'):,}")
-    logger.logger.debug(f"[DEBUG] DEBUG BLOQUE {actual_chunk_count}: overlap_left={metadata.get('overlap_left', 'N/A')}")
-    logger.logger.debug(f"[DEBUG] DEBUG BLOQUE {actual_chunk_count}: overlap_right={metadata.get('overlap_right', 'N/A')}")
+    logger = get_global_logger().logger
+    metadata_str = str(metadata) if metadata else "{}"
+    logger.debug(
+        "Block %d • shape=%s • dtype=%s • metadata=%s",
+        actual_chunk_count,
+        block_shape,
+        block_dtype,
+        metadata_str,
+    )
 
 
 def log_processing_summary(actual_chunk_count: int, chunk_count: int,
@@ -70,10 +75,14 @@ def log_processing_summary(actual_chunk_count: int, chunk_count: int,
         cand_counter_total: Total de candidatos encontrados
         n_bursts_total: Total de bursts detectados
     """
-    logger = get_global_logger()
-    logger.logger.debug(f"[DEBUG] DEBUG RESUMEN: chunks procesados={actual_chunk_count}, total estimado={chunk_count}")
-    logger.logger.debug(f"[DEBUG] DEBUG RESUMEN: candidatos totales={cand_counter_total}, bursts={n_bursts_total}")
-    logger.logger.debug(f"[DEBUG] DEBUG RESUMEN: archivo procesado completamente a través de streaming")
+    logger = get_global_logger().logger
+    logger.info(
+        "Progress • chunks=%d/%d • candidates=%d • bursts=%d",
+        actual_chunk_count,
+        chunk_count,
+        cand_counter_total,
+        n_bursts_total,
+    )
 
 
 def log_pipeline_file_processing(fits_path_name: str, file_suffix: str,
@@ -87,12 +96,14 @@ def log_pipeline_file_processing(fits_path_name: str, file_suffix: str,
         total_samples: Total de muestras del archivo
         chunk_samples: Tamaño configurado del chunk
     """
-    logger = get_global_logger()
-    logger.logger.debug(f"[DEBUG] DEBUG PIPELINE: Procesando archivo: {fits_path_name}")
-    logger.logger.debug(f"[DEBUG] DEBUG PIPELINE: Tipo de archivo: {file_suffix}")
-    logger.logger.debug(f"[DEBUG] DEBUG PIPELINE: Muestras totales: {total_samples:,}")
-    logger.logger.debug(f"[DEBUG] DEBUG PIPELINE: chunk_samples configurado: {chunk_samples:,}")
-    logger.logger.debug(f"[DEBUG] DEBUG PIPELINE: SIEMPRE llamando a _process_file_chunked (nunca a _process_file)")
+    logger = get_global_logger().logger
+    logger.debug(
+        "File processing • %s (%s) • samples=%s • chunk=%s",
+        fits_path_name,
+        file_suffix,
+        f"{total_samples:,}",
+        f"{chunk_samples:,}",
+    )
 
 
 def log_pipeline_file_completion(fits_path_name: str, results: Dict[str, Any]) -> None:
@@ -103,8 +114,11 @@ def log_pipeline_file_completion(fits_path_name: str, results: Dict[str, Any]) -
         fits_path_name: Nombre del archivo
         results: Resultados del procesamiento
     """
-    logger = get_global_logger()
-    logger.logger.debug(f"[DEBUG] DEBUG PIPELINE: Archivo {fits_path_name} procesado exitosamente")
-    logger.logger.debug(f"[DEBUG] DEBUG PIPELINE: Status: {results.get('status', 'N/A')}")
-    logger.logger.debug(f"[DEBUG] DEBUG PIPELINE: Chunks procesados: {results.get('chunks_processed', 'N/A')}")
-    logger.logger.debug(f"[DEBUG] DEBUG PIPELINE: Modo de procesamiento: {results.get('processing_mode', 'N/A')}")
+    logger = get_global_logger().logger
+    logger.debug(
+        "File completed • %s • status=%s • chunks=%s • mode=%s",
+        fits_path_name,
+        results.get("status", "N/A"),
+        results.get("chunks_processed", "N/A"),
+        results.get("processing_mode", "N/A"),
+    )

--- a/src/preprocessing/dedispersion.py
+++ b/src/preprocessing/dedispersion.py
@@ -351,21 +351,21 @@ def dedisperse_block(
 
                                    
     if config.DEBUG_FREQUENCY_ORDER:
-        logger.debug(f" [DEBUG DEDISPERSIÓN] DM: {dm:.2f} pc cm⁻³")
-        logger.debug(f" [DEBUG DEDISPERSIÓN] freq_down shape: {freq_down.shape}")
-        logger.debug(f" [DEBUG DEDISPERSIÓN] Primeras 3 freq_down: {freq_down[:3]}")
-        logger.debug(f" [DEBUG DEDISPERSIÓN] Últimas 3 freq_down: {freq_down[-3:]}")
-        logger.debug(f" [DEBUG DEDISPERSIÓN] freq_down.max(): {freq_down.max():.2f} MHz")
-        logger.debug(f" [DEBUG DEDISPERSIÓN] Primeros 3 delays: {delays[:3]} muestras")
-        logger.debug(f" [DEBUG DEDISPERSIÓN] Últimos 3 delays: {delays[-3:]} muestras")
-        logger.debug(f" [DEBUG DEDISPERSIÓN] max_delay: {delays.max()} muestras")
-        logger.debug(f" [DEBUG DEDISPERSIÓN] Dedispersión esperada: freq ALTAS llegan primero (delay=0), freq BAJAS llegan después (delay>0)")
+        logger.debug(f"[DEBUG DEDISPERSIÓN] DM: {dm:.2f} pc cm⁻³")
+        logger.debug(f"[DEBUG DEDISPERSIÓN] freq_down shape: {freq_down.shape}")
+        logger.debug(f"[DEBUG DEDISPERSIÓN] Primeras 3 freq_down: {freq_down[:3]}")
+        logger.debug(f"[DEBUG DEDISPERSIÓN] Últimas 3 freq_down: {freq_down[-3:]}")
+        logger.debug(f"[DEBUG DEDISPERSIÓN] freq_down.max(): {freq_down.max():.2f} MHz")
+        logger.debug(f"[DEBUG DEDISPERSIÓN] Primeros 3 delays: {delays[:3]} muestras")
+        logger.debug(f"[DEBUG DEDISPERSIÓN] Últimos 3 delays: {delays[-3:]} muestras")
+        logger.debug(f"[DEBUG DEDISPERSIÓN] max_delay: {delays.max()} muestras")
+        logger.debug(f"[DEBUG DEDISPERSIÓN] Dedispersión esperada: freq ALTAS llegan primero (delay=0), freq BAJAS llegan después (delay>0)")
         if freq_down[0] < freq_down[-1]:              
             expected_delay_pattern = "delays DECRECIENTES (de max a 0)"
         else:               
             expected_delay_pattern = "delays CRECIENTES (de 0 a max)"
-        logger.debug(f" [DEBUG DEDISPERSIÓN] Patrón esperado de delays: {expected_delay_pattern}")
-        logger.debug(" [DEBUG DEDISPERSIÓN] " + "="*60)
+        logger.debug(f"[DEBUG DEDISPERSIÓN] Patrón esperado de delays: {expected_delay_pattern}")
+        logger.debug("[DEBUG DEDISPERSIÓN] " + "="*60)
 
     max_delay = int(delays.max())
     if start + block_len + max_delay > data.shape[0]:


### PR DESCRIPTION
## Summary
- modernize the DRAFTS logger to emit concise English messages, propagate handlers to the root logger, and summarize pipeline, chunk and candidate events without duplication
- condense chunking/pipeline helper logs and rewrite pipeline stages to avoid per-slice noise while keeping key file, chunk, memory and detection information
- replace ad-hoc print statements across FITS/filterbank handlers, preprocessing and utilities with structured logging so detailed diagnostics move to DEBUG level and warnings/errors are emitted once

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c99892858483229037ec4c19e8eb1c