### PR TITLE
Implement high-frequency FRB strategies

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -35,6 +35,30 @@ try:
         SAVE_ONLY_BURST,
         AUTO_HIGH_FREQ_PIPELINE,
         HIGH_FREQ_THRESHOLD_MHZ,
+        HF_BOW_TIE_MIN_DM_INDEX,
+        HF_BOW_TIE_MIN_SNR,
+        HF_BOW_TIE_THRESHOLD,
+        HF_BOW_TIE_WING_WIDTH,
+        HF_DEDUP_DM_TOL,
+        HF_DEDUP_TIME_TOL_SEC,
+        HF_DM_COARSE_STEP,
+        HF_DM_EXPANSION_FACTOR,
+        HF_DM_MIN_STEP,
+        HF_MIN_SIGNIFICANT_DM,
+        HF_MONITOR_BOW_TIE_RATIO,
+        HF_SUBBAND_CONSISTENCY_THRESHOLD,
+        HF_SUBBAND_COUNT,
+        HF_SUBBAND_SNR_THRESHOLD,
+        HF_TEMPORAL_CHUNK_SEC,
+        HF_TEMPORAL_SNR_THRESHOLD,
+        HF_VALIDATION_DM_MAX,
+        HF_VALIDATION_DM_MIN,
+        HF_VALIDATION_DM_STEP,
+        HF_VALIDATION_PATCH_LEN,
+        HF_ZERO_DM_MAX_CANDIDATES,
+        HF_ZERO_DM_MIN_SNR,
+        HF_ZERO_DM_SENSITIVITY,
+        HF_ZERO_DM_TRIALS,
     )
 except ImportError:
                                              
@@ -56,19 +80,75 @@ except ImportError:
         SAVE_ONLY_BURST,
         AUTO_HIGH_FREQ_PIPELINE,
         HIGH_FREQ_THRESHOLD_MHZ,
+        HF_BOW_TIE_MIN_DM_INDEX,
+        HF_BOW_TIE_MIN_SNR,
+        HF_BOW_TIE_THRESHOLD,
+        HF_BOW_TIE_WING_WIDTH,
+        HF_DEDUP_DM_TOL,
+        HF_DEDUP_TIME_TOL_SEC,
+        HF_DM_COARSE_STEP,
+        HF_DM_EXPANSION_FACTOR,
+        HF_DM_MIN_STEP,
+        HF_MIN_SIGNIFICANT_DM,
+        HF_MONITOR_BOW_TIE_RATIO,
+        HF_SUBBAND_CONSISTENCY_THRESHOLD,
+        HF_SUBBAND_COUNT,
+        HF_SUBBAND_SNR_THRESHOLD,
+        HF_TEMPORAL_CHUNK_SEC,
+        HF_TEMPORAL_SNR_THRESHOLD,
+        HF_VALIDATION_DM_MAX,
+        HF_VALIDATION_DM_MIN,
+        HF_VALIDATION_DM_STEP,
+        HF_VALIDATION_PATCH_LEN,
+        HF_ZERO_DM_MAX_CANDIDATES,
+        HF_ZERO_DM_MIN_SNR,
+        HF_ZERO_DM_SENSITIVITY,
+        HF_ZERO_DM_TRIALS,
     )
 
                           
 from pathlib import Path
 
-                     
+
 import numpy as np
 
-                              
+
 try:
     import torch
-except ImportError:                                                    
+except ImportError:
     torch = None
+
+
+_HF_DEFAULTS = {
+    'HF_DM_EXPANSION_FACTOR': 3.0,
+    'HF_DM_COARSE_STEP': 5.0,
+    'HF_DM_MIN_STEP': 1.0,
+    'HF_BOW_TIE_THRESHOLD': 2.0,
+    'HF_BOW_TIE_WING_WIDTH': 20,
+    'HF_BOW_TIE_MIN_DM_INDEX': 10,
+    'HF_BOW_TIE_MIN_SNR': 5.0,
+    'HF_ZERO_DM_TRIALS': [0.0, 1.0, 2.0, 5.0],
+    'HF_ZERO_DM_SENSITIVITY': 0.4,
+    'HF_ZERO_DM_MIN_SNR': 3.5,
+    'HF_ZERO_DM_MAX_CANDIDATES': 1000,
+    'HF_MIN_SIGNIFICANT_DM': 15.0,
+    'HF_VALIDATION_DM_MIN': 0.0,
+    'HF_VALIDATION_DM_MAX': 6000.0,
+    'HF_VALIDATION_DM_STEP': 5.0,
+    'HF_VALIDATION_PATCH_LEN': 256,
+    'HF_SUBBAND_COUNT': 4,
+    'HF_SUBBAND_SNR_THRESHOLD': 5.0,
+    'HF_SUBBAND_CONSISTENCY_THRESHOLD': 0.75,
+    'HF_TEMPORAL_CHUNK_SEC': 30.0,
+    'HF_TEMPORAL_SNR_THRESHOLD': 5.0,
+    'HF_DEDUP_TIME_TOL_SEC': 1.0,
+    'HF_DEDUP_DM_TOL': 50.0,
+    'HF_MONITOR_BOW_TIE_RATIO': 0.1,
+}
+
+for _key, _value in _HF_DEFAULTS.items():
+    if _key not in globals():
+        globals()[_key] = _value
 
                                                                                
                                     

--- a/src/config/user_config.py
+++ b/src/config/user_config.py
@@ -66,6 +66,38 @@ AUTO_HIGH_FREQ_PIPELINE: bool = True
 # Central frequency threshold (MHz) to consider "high frequency"
 HIGH_FREQ_THRESHOLD_MHZ: float = 8000.0
 
+# --- Yong-Kun Zhang high-frequency strategies --------------------------------
+
+# Strategy 1 (bow-tie recovery) parameters
+HF_DM_EXPANSION_FACTOR: float = 3.0          # Multiplier for the traditional DM range
+HF_DM_COARSE_STEP: float = 5.0               # Coarse DM step (pc cm⁻³)
+HF_DM_MIN_STEP: float = 1.0                  # Minimum DM step to guarantee coverage
+HF_BOW_TIE_THRESHOLD: float = 2.0            # Minimum contrast required for bow-tie pattern
+HF_BOW_TIE_WING_WIDTH: int = 20              # Samples used to estimate bow-tie wings
+HF_BOW_TIE_MIN_DM_INDEX: int = 10            # Minimum DM index to accept a bow-tie candidate
+HF_BOW_TIE_MIN_SNR: float = 5.0              # Minimum SNR for bow-tie detections
+
+# Strategy 2 (zero-DM + validation) parameters
+HF_ZERO_DM_TRIALS = [0.0, 1.0, 2.0, 5.0]     # DM trials around zero for permissive detection
+HF_ZERO_DM_SENSITIVITY: float = 0.4          # Minimum class probability in permissive stage
+HF_ZERO_DM_MIN_SNR: float = 3.5              # Minimum SNR to keep zero-DM candidates
+HF_ZERO_DM_MAX_CANDIDATES: int = 1000        # Limit of candidates processed in validation
+HF_MIN_SIGNIFICANT_DM: float = 15.0          # Minimum DM considered astrophysically valid
+HF_VALIDATION_DM_MIN: float = 0.0            # DM search lower bound during validation
+HF_VALIDATION_DM_MAX: float = 6000.0         # DM search upper bound during validation
+HF_VALIDATION_DM_STEP: float = 5.0           # DM step during validation scan
+HF_VALIDATION_PATCH_LEN: int = 256           # Samples used in validation patches
+HF_SUBBAND_COUNT: int = 4                    # Sub-bands used to verify consistency
+HF_SUBBAND_SNR_THRESHOLD: float = 5.0        # Minimum SNR per sub-band
+HF_SUBBAND_CONSISTENCY_THRESHOLD: float = 0.75  # Required fraction of consistent sub-bands
+HF_TEMPORAL_CHUNK_SEC: float = 30.0          # Temporal window for consistency checks
+HF_TEMPORAL_SNR_THRESHOLD: float = 5.0       # Minimum SNR in independent chunk reprocessing
+HF_DEDUP_TIME_TOL_SEC: float = 1.0           # Time tolerance for deduplication (seconds)
+HF_DEDUP_DM_TOL: float = 50.0                # DM tolerance for deduplication (pc cm⁻³)
+
+# Monitoring thresholds for the integrated pipeline
+HF_MONITOR_BOW_TIE_RATIO: float = 0.1        # Expected minimum ratio of bow-tie recoveries
+
 # =============================================================================
 # POLARIZATION CONFIGURATION (PSRFITS INPUT)
 # =============================================================================

--- a/src/core/high_freq_pipeline.py
+++ b/src/core/high_freq_pipeline.py
@@ -1,247 +1,87 @@
+"""High-frequency FRB pipeline integrating Yong-Kun Zhang's strategies."""
+
 from __future__ import annotations
 
-# Standard library imports
-from dataclasses import dataclass
-from pathlib import Path
 import logging
+import time
+from pathlib import Path
 
-# Third-party imports
 import numpy as np
 
-# Local imports
 from ..config import config
-from ..analysis.snr_utils import compute_snr_profile, find_snr_peak
-from ..logging.logging_config import Colors, get_global_logger
+from ..logging.logging_config import get_global_logger
 from ..output.candidate_manager import Candidate, append_candidate
-from ..preprocessing.dedispersion import dedisperse_block, dedisperse_patch
-from ..visualization.visualization_unified import preprocess_img, postprocess_img
+from ..visualization.visualization_unified import preprocess_img, postprocess_img, save_all_plots
+from .high_freq_strategies import (
+    ExpandedDMRange,
+    HighFreqCandidate,
+    calculate_expanded_dm_range,
+    deduplicate_and_rank_candidates,
+    dm_aware_validation,
+    generate_time_dm_plane,
+    monitor_pipeline_health,
+    run_bow_tie_strategy,
+    zero_dm_classifier,
+)
+
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class PeakCandidateBox:
-    x1: int
-    y1: int
-    x2: int
-    y2: int
-
-
-def _find_snr_peaks(snr_profile: np.ndarray, threshold: float, min_distance: int = 16) -> list[int]:
-    """Return time indices where the SNR exceeds the threshold and is a local maximum."""
-    if snr_profile is None or snr_profile.size == 0:
-        return []
-    peaks: list[int] = []
-    n = snr_profile.size
-    for i in range(1, n - 1):
-        if snr_profile[i] >= threshold and snr_profile[i] >= snr_profile[i - 1] and snr_profile[i] >= snr_profile[i + 1]:
-            if not peaks or (i - peaks[-1]) >= min_distance:
-                peaks.append(i)
-    return peaks
-
-
-def _dm_from_image_at_time(dm_time_band_img: np.ndarray, time_idx: int) -> float:
-    """Map a time index to the DM row with the highest intensity."""
-    h, w = dm_time_band_img.shape[:2]
-    t = int(max(0, min(w - 1, time_idx)))
-    row_idx = int(np.argmax(dm_time_band_img[:, t]))
-    # Map the row index linearly between DM_min and DM_max.
-    dm_min = float(config.DM_min)
-    dm_max = float(config.DM_max)
-    dm_val = dm_min + (row_idx / max(h - 1, 1)) * (dm_max - dm_min)
-    return float(dm_val)
-
-
-def snr_detect_and_classify_candidates_in_band(
-    cls_model,
-    band_img: np.ndarray,  # DM x time image used for visualisation
-    waterfall_block: np.ndarray,  # time x frequency slice block
-    slice_len: int,
-    j: int,
-    fits_path: Path,
-    save_dir: Path,
-    data_block: np.ndarray,  # decimated chunk block
-    freq_down: np.ndarray,
+def _append_candidates_to_csv(
+    candidates: list[HighFreqCandidate],
     csv_file: Path,
-    time_reso_ds: float,
-    snr_list: list,
-    absolute_start_time: float | None,
-    patches_dir: Path | None,
-    chunk_idx: int | None,
-    band_idx: int,
-    slice_start_idx: int,  # actual slice start in decimated samples
-) -> dict:
-    """Detect candidates from SNR peaks and classify them with the binary network."""
-    try:
-        global_logger = get_global_logger()
-    except Exception:
-        global_logger = None
+    fits_path: Path,
+    chunk_idx: int,
+    slice_idx: int,
+    patch_name: str | None,
+) -> tuple[int, int]:
+    """Persist candidates into the CSV file and return burst counts."""
 
-    # Compute the SNR profile on the waterfall (time × frequency).
-    snr_profile, _, _ = compute_snr_profile(waterfall_block)
-    peaks = _find_snr_peaks(snr_profile, float(config.SNR_THRESH))
-    # Ensure the first candidate corresponds to the main SNR peak used downstream.
-    peak_snr_global, _, peak_idx_global = find_snr_peak(snr_profile)
-    if peak_snr_global >= float(config.SNR_THRESH):
-        # Insert at the front if absent, otherwise move it to the front.
-        peaks = [peak_idx_global] + [p for p in peaks if p != peak_idx_global]
-    else:
-        # If the global peak is below threshold, keep a sorted list (possibly empty).
-        peaks = sorted(peaks, key=lambda p: snr_profile[p], reverse=True)
-
-    if global_logger:
-        band_names = ["Full Band", "Low Band", "High Band"]
-        band_name = band_names[band_idx] if band_idx < len(band_names) else f"Band {band_idx}"
-        global_logger.band_candidates(band_name, len(peaks))
-
-    # Geometry parameters for synthetic boxes in the original band_img space.
-    img_h, img_w = band_img.shape[:2]
-    half_w = max(4, slice_len // 64)
-    half_h = max(3, img_h // 32)
-    # Scale factors that match the 512x512 network input.
-    target_w = 512
-    target_h = 512
-    scale_x = float(target_w) / float(max(1, img_w))
-    scale_y = float(target_h) / float(max(1, img_h))
-
-    # Outputs accumulated for compatibility with the main pipeline.
-    top_conf: list[float] = []
-    top_boxes: list[tuple[int, int, int, int]] = []
-    class_probs_list: list[float] = []
-    candidate_times_abs: list[float] = []
-    cand_counter = 0
     n_bursts = 0
     n_no_bursts = 0
-    prob_max = 0.0
-
-    # Track the best candidate for the composite view.
-    best_patch = None
-    best_start = None
-    best_dm = None
-    best_is_burst = False
-
-    # Patch directory for saving cut-outs.
-    if patches_dir is not None:
-        patch_path = patches_dir / f"patch_slice{j}_band{band_idx}.png"
-    else:
-        patch_path = (save_dir / "Patches" / fits_path.stem / f"patch_slice{j}_band{band_idx}.png")
-
-    for peak_idx in peaks:
-        # Create a box centred on the peak.
-        cx = int(max(0, min(img_w - 1, peak_idx)))
-        dm_val = _dm_from_image_at_time(band_img, cx)
-        cy_row = int(round((dm_val - float(config.DM_min)) / max(float(config.DM_max - config.DM_min), 1e-6) * (img_h - 1)))
-        x1_raw = max(0, cx - half_w)
-        x2_raw = min(img_w - 1, cx + half_w)
-        y1_raw = max(0, cy_row - half_h)
-        y2_raw = min(img_h - 1, cy_row + half_h)
-        # Transform the box to 512x512 coordinates to match img_rgb.
-        x1 = int(round(x1_raw * scale_x))
-        x2 = int(round(x2_raw * scale_x))
-        y1 = int(round(y1_raw * scale_y))
-        y2 = int(round(y2_raw * scale_y))
-        box = (x1, y1, x2, y2)
-
-        # Confidence derived from the SNR value (clipped to a sensible range).
-        snr_peak = float(snr_profile[peak_idx])
-        conf = float(min(0.99, max(0.05, snr_peak / 10.0)))
-
-        # Dedisperse a patch around the global peak time.
-        global_sample = int(slice_start_idx) + int(peak_idx)
-        patch, start_sample = dedisperse_patch(data_block, freq_down, dm_val, global_sample)
-
-        snr_val = 0.0
-        peak_idx_patch = None
-        if patch is not None and patch.size > 0:
-            snr_profile_pre, _, best_w_vec = compute_snr_profile(patch)
-            if snr_profile_pre.size > 0:
-                peak_idx_patch = int(np.argmax(snr_profile_pre))
-                snr_val = float(np.max(snr_profile_pre))
-        else:
-            snr_val = snr_peak
-
-        # Binary classification.
-        from ..detection.model_interface import classify_patch
-        class_prob, proc_patch = classify_patch(cls_model, patch)
-        is_burst = class_prob >= float(config.CLASS_PROB)
-        
-        # Force the candidate time to align with the waterfall SNR peak.
-        absolute_candidate_time = (absolute_start_time or 0.0) + (peak_idx * time_reso_ds)
-
-        # Record outputs.
-        snr_list.append(snr_peak)
-        top_conf.append(conf)
-        top_boxes.append(box)
-        class_probs_list.append(class_prob)
-        candidate_times_abs.append(float(absolute_candidate_time))
-
-        # Keep track of the best candidate.
-        if best_patch is None or (is_burst and not best_is_burst):
-            best_patch = proc_patch
-            best_start = absolute_candidate_time
-            best_dm = dm_val
-            best_is_burst = is_burst
-
-        # Build the CSV row and estimate width_ms using the optimal width at the peak.
-        width_ms = None
-        try:
-            if peak_idx_patch is not None and 'best_w_vec' in locals() and best_w_vec.size > 0:
-                width_ms = float(best_w_vec[int(peak_idx_patch)] * time_reso_ds * 1000.0)
-        except Exception:
-            width_ms = None
-
-        cand = Candidate(
-            fits_path.name,
-            chunk_idx if chunk_idx is not None else 0,
-            j,
-            band_idx,
-            float(conf),
-            float(dm_val),
-            float(absolute_candidate_time),
-            int(peak_idx),
-            tuple(map(int, box)),
-            float(snr_val),
-            float(class_prob),
-            bool(is_burst),
-            patch_path.name,
-            width_ms,
-        )
-        cand_counter += 1
+    for cand in candidates:
+        is_burst = cand.is_burst()
+        if not config.SAVE_ONLY_BURST or is_burst:
+            candidate_row = Candidate(
+                file=fits_path.name,
+                chunk_id=int(chunk_idx),
+                slice_id=int(slice_idx),
+                band_id=int(cand.band_idx),
+                prob=float(cand.confidence),
+                dm=float(cand.effective_dm()),
+                t_sec=float(cand.absolute_time),
+                t_sample=int(cand.global_sample),
+                box=tuple(map(int, cand.candidate_box or (0, 0, 0, 0))),
+                snr=float(cand.snr),
+                class_prob=float(cand.class_prob),
+                is_burst=bool(is_burst),
+                patch_file=patch_name,
+                width_ms=(
+                    float(cand.width_samples * config.TIME_RESO * config.DOWN_TIME_RATE * 1000.0)
+                    if cand.width_samples is not None
+                    else None
+                ),
+            )
+            append_candidate(csv_file, candidate_row.to_row())
+            try:
+                gl = get_global_logger()
+                gl.candidate_detected(
+                    cand.effective_dm(),
+                    cand.absolute_time,
+                    cand.confidence,
+                    cand.class_prob,
+                    is_burst,
+                    cand.snr,
+                    cand.snr,
+                )
+            except Exception:
+                pass
         if is_burst:
             n_bursts += 1
         else:
             n_no_bursts += 1
-        prob_max = max(prob_max, float(conf))
-
-        if not config.SAVE_ONLY_BURST or is_burst:
-            append_candidate(csv_file, cand.to_row())
-            try:
-                gl = get_global_logger()
-                gl.candidate_detected(dm_val, absolute_candidate_time, conf, class_prob, is_burst, snr_peak, snr_val)
-            except Exception:
-                pass
-
-    # Generate an RGB image using the same colour pipeline as the standard flow.
-    img_tensor = preprocess_img(band_img)
-    img_rgb = postprocess_img(img_tensor)
-
-    return {
-        "top_conf": top_conf,
-        "top_boxes": top_boxes,
-        "class_probs_list": class_probs_list,
-        "first_patch": best_patch,
-        "first_start": best_start,
-        "first_dm": best_dm,
-        "img_rgb": img_rgb,
-        "cand_counter": cand_counter,
-        "n_bursts": n_bursts,
-        "n_no_bursts": n_no_bursts,
-        "prob_max": prob_max,
-        "patch_path": patch_path,
-        "best_is_burst": best_is_burst,
-        "total_candidates": cand_counter,
-        "candidate_times_abs": candidate_times_abs,
-    }
+    return n_bursts, n_no_bursts
 
 
 def process_slice_with_multiple_bands_high_freq(
@@ -264,8 +104,10 @@ def process_slice_with_multiple_bands_high_freq(
     chunk_idx: int | None,
     slice_start_idx: int,
     slice_end_idx: int,
-) -> tuple[int, int, int, float]:
-    """Process a slice using SNR peaks instead of the object detector."""
+    dm_range: ExpandedDMRange,
+) -> dict:
+    """Process a slice combining bow-tie recovery and zero-DM validation."""
+
     try:
         global_logger = get_global_logger()
     except Exception:
@@ -273,75 +115,128 @@ def process_slice_with_multiple_bands_high_freq(
 
     start_idx = int(slice_start_idx)
     end_idx = int(slice_end_idx)
+    if end_idx <= start_idx:
+        return {
+            "cand_counter": 0,
+            "n_bursts": 0,
+            "n_no_bursts": 0,
+            "prob_max": 0.0,
+            "strategy_1_count": 0,
+            "strategy_2_initial_count": 0,
+            "strategy_2_validated_count": 0,
+            "final_candidate_count": 0,
+            "all_candidates_initial": 0,
+        }
+
     slice_cube = dm_time[:, :, start_idx:end_idx]
     waterfall_block = block[start_idx:end_idx]
     if slice_cube.size == 0 or waterfall_block.size == 0:
-        return 0, 0, 0, 0.0
+        return {
+            "cand_counter": 0,
+            "n_bursts": 0,
+            "n_no_bursts": 0,
+            "prob_max": 0.0,
+            "strategy_1_count": 0,
+            "strategy_2_initial_count": 0,
+            "strategy_2_validated_count": 0,
+            "final_candidate_count": 0,
+            "all_candidates_initial": 0,
+        }
 
+    chunk_idx_int = int(chunk_idx) if chunk_idx is not None else 0
     fits_stem = fits_path.stem
     if composite_dir is not None:
         comp_path = composite_dir / f"{fits_stem}_slice{j:03d}.png"
     else:
         comp_path = save_dir / "Composite" / f"{fits_stem}_slice{j:03d}.png"
 
-    cand_counter = 0
-    n_bursts = 0
-    n_no_bursts = 0
-    prob_max = 0.0
-    slice_has_candidates = False
+    abs_start = float(absolute_start_time or 0.0)
 
-    # Process all configured bands.
+    zero_dm_candidates = zero_dm_classifier(
+        block,
+        freq_down,
+        start_idx,
+        end_idx,
+        cls_model=cls_model,
+        absolute_start_time=abs_start,
+        chunk_idx=chunk_idx_int,
+        slice_idx=j,
+        dt_ds=time_reso_ds,
+        dm_range=dm_range,
+    )
+    validated_candidates = dm_aware_validation(zero_dm_candidates, block, freq_down, time_reso_ds, dm_range)
+
+    strategy1_candidates: list[HighFreqCandidate] = []
     for band_idx, band_suffix, band_name in band_configs:
         band_img = slice_cube[band_idx]
-        result = snr_detect_and_classify_candidates_in_band(
-            cls_model,
+        band_candidates = run_bow_tie_strategy(
             band_img,
-            waterfall_block,
-            end_idx - start_idx,
-            j,
-            fits_path,
-            save_dir,
-            block,
-            freq_down,
-            csv_file,
-            time_reso_ds,
-            snr_list,
-            absolute_start_time,
-            patches_dir,
-            chunk_idx,
-            band_idx,
-            start_idx,
+            dm_range,
+            block=block,
+            freq_down=freq_down,
+            start_idx=start_idx,
+            absolute_start_time=abs_start,
+            cls_model=cls_model,
+            chunk_idx=chunk_idx_int,
+            slice_idx=j,
+            band_idx=band_idx,
+            dt_ds=time_reso_ds,
         )
-        cand_counter += result["cand_counter"]
-        n_bursts += result["n_bursts"]
-        n_no_bursts += result["n_no_bursts"]
-        prob_max = max(prob_max, result["prob_max"])
-        if len(result["top_conf"]) > 0:
-            slice_has_candidates = True
+        strategy1_candidates.extend(band_candidates)
+        if global_logger:
+            try:
+                global_logger.band_candidates(band_name, len(band_candidates))
+            except Exception:
+                pass
 
-        # Decide whether plots should be generated.
-        should_generate_plots = (slice_has_candidates or config.FORCE_PLOTS)
-        if config.SAVE_ONLY_BURST:
-            should_generate_plots = (n_bursts > 0) or config.FORCE_PLOTS
+    all_candidates = strategy1_candidates + validated_candidates
+    final_candidates = deduplicate_and_rank_candidates(all_candidates)
 
-        if should_generate_plots:
-            dm_to_use = result["first_dm"] if result["first_dm"] is not None else 0.0
-            dedisp_block = dedisperse_block(block, freq_down, dm_to_use, start_idx, end_idx - start_idx)
+    for cand in final_candidates:
+        snr_list.append(float(cand.snr))
+
+    best_candidate = final_candidates[0] if final_candidates else None
+    prob_max = max((cand.confidence for cand in final_candidates), default=0.0)
+    cand_counter = len(final_candidates)
+    n_bursts = sum(1 for cand in final_candidates if cand.is_burst())
+    n_no_bursts = cand_counter - n_bursts
+
+    if final_candidates:
+        band_idx_plot = int(best_candidate.band_idx)
+        band_map = {idx: (suffix, name) for idx, suffix, name in band_configs}
+        band_suffix = band_map.get(band_idx_plot, ("fullband", "Full Band"))[0]
+        band_name = band_map.get(band_idx_plot, ("fullband", "Full Band"))[1]
+        band_img = slice_cube[band_idx_plot]
+        img_tensor = preprocess_img(band_img)
+        img_rgb = postprocess_img(img_tensor)
+        dedisp_dm = best_candidate.effective_dm()
+        dedisp_block = generate_dedispersed_block(block, freq_down, start_idx, end_idx, dedisp_dm)
+        patch_dir = patches_dir if patches_dir is not None else (save_dir / "Patches" / fits_stem)
+        patch_dir.mkdir(parents=True, exist_ok=True)
+        patch_path = patch_dir / f"patch_slice{j}_band{band_idx_plot}.png"
+        first_patch = best_candidate.processed_patch
+        if first_patch is None:
+            first_patch = regenerate_patch(block, freq_down, best_candidate, cls_model)
+            best_candidate.processed_patch = first_patch
+        if global_logger:
             try:
                 global_logger.generating_plots()
             except Exception:
                 pass
-            from ..visualization.visualization_unified import save_all_plots
+        should_generate_plots = bool(final_candidates) or config.FORCE_PLOTS
+        if config.SAVE_ONLY_BURST:
+            should_generate_plots = (n_bursts > 0) or config.FORCE_PLOTS
+        if should_generate_plots:
             save_all_plots(
                 waterfall_block,
                 dedisp_block,
-                result["img_rgb"],
-                result["first_patch"],
-                result["first_start"],
-                result["first_dm"],
-                result["top_conf"],
-                result["top_boxes"],
-                result["class_probs_list"],
+                img_rgb,
+                first_patch,
+                best_candidate.absolute_time,
+                dedisp_dm,
+                [cand.confidence for cand in final_candidates],
+                [cand.candidate_box or (0, 0, 0, 0) for cand in final_candidates],
+                [cand.class_prob for cand in final_candidates],
                 comp_path,
                 j,
                 block.shape[0] // slice_len + (1 if block.shape[0] % slice_len != 0 else 0),
@@ -351,18 +246,76 @@ def process_slice_with_multiple_bands_high_freq(
                 end_idx - start_idx,
                 normalize=True,
                 off_regions=None,
-                thresh_snr=config.SNR_THRESH,
-                band_idx=band_idx,
-                patch_path=result["patch_path"],
-                absolute_start_time=absolute_start_time,
-                chunk_idx=chunk_idx,
+                thresh_snr=getattr(config, "SNR_THRESH", 4.0),
+                band_idx=band_idx_plot,
+                patch_path=patch_path,
+                absolute_start_time=abs_start,
+                chunk_idx=chunk_idx_int,
                 force_plots=config.FORCE_PLOTS,
+                candidate_times_abs=[cand.absolute_time for cand in final_candidates],
             )
+    else:
+        patch_path = None
 
-    # Effective metrics after applying the SAVE_ONLY_BURST flag.
+    extra_bursts, extra_non_bursts = _append_candidates_to_csv(
+        final_candidates,
+        csv_file,
+        fits_path,
+        chunk_idx_int,
+        j,
+        patch_path.name if patch_path is not None else None,
+    )
+    # Ensure counts align with actual persisted rows when SAVE_ONLY_BURST is enabled.
     if config.SAVE_ONLY_BURST:
-        return n_bursts, n_bursts, 0, prob_max
-    return cand_counter, n_bursts, n_no_bursts, prob_max
+        n_bursts = extra_bursts
+        n_no_bursts = 0
+
+    return {
+        "cand_counter": cand_counter,
+        "n_bursts": n_bursts,
+        "n_no_bursts": n_no_bursts,
+        "prob_max": prob_max,
+        "strategy_1_count": len(strategy1_candidates),
+        "strategy_2_initial_count": len(zero_dm_candidates),
+        "strategy_2_validated_count": len(validated_candidates),
+        "final_candidate_count": len(final_candidates),
+        "all_candidates_initial": len(strategy1_candidates) + len(validated_candidates),
+    }
+
+
+def regenerate_patch(block: np.ndarray, freq_down: np.ndarray, candidate: HighFreqCandidate, cls_model):
+    from ..preprocessing.dedispersion import dedisperse_patch
+    patch, _ = dedisperse_patch(block, freq_down, candidate.effective_dm(), candidate.global_sample)
+    _, proc_patch = classify_patch_safe(cls_model, patch)
+    return proc_patch
+
+
+def generate_dedispersed_block(
+    block: np.ndarray,
+    freq_down: np.ndarray,
+    start_idx: int,
+    end_idx: int,
+    dm_val: float,
+) -> np.ndarray:
+    from ..preprocessing.dedispersion import dedisperse_block
+
+    return dedisperse_block(block, freq_down, dm_val, start_idx, end_idx - start_idx)
+
+
+def classify_patch_safe(model, patch: np.ndarray):
+    from ..detection.model_interface import classify_patch
+
+    if patch is None or patch.size == 0:
+        return 0.0, np.zeros((1, 1), dtype=np.float32)
+    return classify_patch(model, patch)
+
+
+def _log_chunk_start(metadata: dict) -> None:
+    if not config.DEBUG_FREQUENCY_ORDER:
+        return
+    start = metadata.get("start_sample")
+    chunk_idx = metadata.get("chunk_idx")
+    logger.debug("Processing chunk %s starting at sample %s", chunk_idx, start)
 
 
 def _process_file_chunked_high_freq(
@@ -372,9 +325,9 @@ def _process_file_chunked_high_freq(
     chunk_samples: int,
     streaming_func,
 ) -> dict:
-    """Simplified version of ``_process_file_chunked`` using the SNR-driven flow."""
+    """Run the high-frequency pipeline over a file in streaming chunks."""
+
     from .data_flow_manager import (
-        build_dm_time_cube,
         create_chunk_directories,
         downsample_chunk,
         get_chunk_processing_parameters,
@@ -383,7 +336,6 @@ def _process_file_chunked_high_freq(
     )
     from ..output.candidate_manager import ensure_csv_header
     from ..logging import log_block_processing, log_streaming_parameters
-    import time
 
     csv_file = save_dir / f"{fits_path.stem}.candidates.csv"
     ensure_csv_header(csv_file)
@@ -395,41 +347,57 @@ def _process_file_chunked_high_freq(
     prob_max_total = 0.0
     snr_list_total: list[float] = []
     actual_chunk_count = 0
+    strategy1_total = 0
+    strategy2_initial_total = 0
+    strategy2_validated_total = 0
+    final_candidate_total = 0
+    all_candidates_initial_total = 0
 
-    # Streaming parameters reused from the main pipeline.
     total_samples = config.FILE_LENG
-    freq_ds = np.mean(config.FREQ.reshape(config.FREQ_RESO // config.DOWN_FREQ_RATE, config.DOWN_FREQ_RATE), axis=1)
+    freq_ds = np.mean(
+        config.FREQ.reshape(config.FREQ_RESO // config.DOWN_FREQ_RATE, config.DOWN_FREQ_RATE),
+        axis=1,
+    )
     nu_min = float(freq_ds.min())
     nu_max = float(freq_ds.max())
     dt_max_sec = 4.1488e3 * config.DM_max * (nu_min ** -2 - nu_max ** -2)
     overlap_raw = int(np.ceil(dt_max_sec / config.TIME_RESO))
     log_streaming_parameters(chunk_samples, overlap_raw, total_samples, chunk_samples, streaming_func, "fits/fil")
 
+    dm_range = calculate_expanded_dm_range(
+        traditional_max_dm=config.DM_max,
+        multiplier=getattr(config, "HF_DM_EXPANSION_FACTOR", 3.0),
+        step_coarse=getattr(config, "HF_DM_COARSE_STEP", 5.0),
+        min_dm=config.DM_min,
+        min_step=getattr(config, "HF_DM_MIN_STEP", 1.0),
+    )
+
     for block, metadata in streaming_func(str(fits_path), chunk_samples, overlap_samples=overlap_raw):
         actual_chunk_count += 1
         log_block_processing(actual_chunk_count, block.shape, str(block.dtype), metadata)
+        _log_chunk_start(metadata)
 
-        # Downsample and extract the valid window.
         block_ds, dt_ds = downsample_chunk(block)
         chunk_params = get_chunk_processing_parameters(metadata)
-        freq_down = chunk_params['freq_down']
-        slice_len = chunk_params['slice_len']
-        time_slice = chunk_params['time_slice']
-        overlap_left_ds = chunk_params['overlap_left_ds']
-        overlap_right_ds = chunk_params['overlap_right_ds']
+        freq_down = chunk_params["freq_down"]
+        slice_len = chunk_params["slice_len"]
+        overlap_left_ds = chunk_params["overlap_left_ds"]
+        overlap_right_ds = chunk_params["overlap_right_ds"]
 
-        dm_time_full = build_dm_time_cube(block_ds, height=chunk_params['height'], dm_min=config.DM_min, dm_max=config.DM_max)
-        block_ds, dm_time, valid_start_ds, valid_end_ds = trim_valid_window(block_ds, dm_time_full, overlap_left_ds, overlap_right_ds)
+        dm_time_full = generate_time_dm_plane(block_ds, dm_range)
+        block_ds, dm_time, valid_start_ds, valid_end_ds = trim_valid_window(
+            block_ds,
+            dm_time_full,
+            overlap_left_ds,
+            overlap_right_ds,
+        )
 
-        # Plan slices.
-        slices_to_process = plan_slices(block_ds, slice_len, metadata['chunk_idx'])
-        composite_dir, detections_dir, patches_dir = create_chunk_directories(save_dir, fits_path, metadata['chunk_idx'])
-
-        # Match the classic pipeline's chunk start time computation.
+        slices_to_process = plan_slices(block_ds, slice_len, metadata["chunk_idx"])
+        composite_dir, detections_dir, patches_dir = create_chunk_directories(save_dir, fits_path, metadata["chunk_idx"])
         chunk_start_time_sec = metadata["start_sample"] * config.TIME_RESO
 
         for j, start_idx, end_idx in slices_to_process:
-            cands, bursts, nobursts, pmax = process_slice_with_multiple_bands_high_freq(
+            slice_result = process_slice_with_multiple_bands_high_freq(
                 j=j,
                 dm_time=dm_time,
                 block=block_ds,
@@ -446,14 +414,21 @@ def _process_file_chunked_high_freq(
                 composite_dir=composite_dir,
                 detections_dir=detections_dir,
                 patches_dir=patches_dir,
-                chunk_idx=metadata['chunk_idx'],
+                chunk_idx=metadata["chunk_idx"],
                 slice_start_idx=start_idx,
                 slice_end_idx=end_idx,
+                dm_range=dm_range,
             )
-            cand_counter_total += cands
-            n_bursts_total += bursts
-            n_no_bursts_total += nobursts
-            prob_max_total = max(prob_max_total, pmax)
+
+            cand_counter_total += slice_result["cand_counter"]
+            n_bursts_total += slice_result["n_bursts"]
+            n_no_bursts_total += slice_result["n_no_bursts"]
+            prob_max_total = max(prob_max_total, slice_result["prob_max"])
+            strategy1_total += slice_result["strategy_1_count"]
+            strategy2_initial_total += slice_result["strategy_2_initial_count"]
+            strategy2_validated_total += slice_result["strategy_2_validated_count"]
+            final_candidate_total += slice_result["final_candidate_count"]
+            all_candidates_initial_total += slice_result["all_candidates_initial"]
 
     runtime = time.time() - t_start
     if config.SAVE_ONLY_BURST:
@@ -465,7 +440,7 @@ def _process_file_chunked_high_freq(
         effective_n_bursts_total = n_bursts_total
         effective_n_no_bursts_total = n_no_bursts_total
 
-    return {
+    result = {
         "n_candidates": effective_cand_counter_total,
         "n_bursts": effective_n_bursts_total,
         "n_no_bursts": effective_n_no_bursts_total,
@@ -473,6 +448,33 @@ def _process_file_chunked_high_freq(
         "max_prob": prob_max_total,
         "mean_snr": float(np.mean(snr_list_total)) if snr_list_total else 0.0,
         "status": "SUCCESS_CHUNKED_HIGH_FREQ",
+        "processing_stats": {
+            "total_processing_time": runtime,
+            "strategy_1_count": strategy1_total,
+            "strategy_2_initial_count": strategy2_initial_total,
+            "strategy_2_validated_count": strategy2_validated_total,
+            "final_unique_count": final_candidate_total,
+            "all_candidates_initial": all_candidates_initial_total,
+            "actual_chunks": actual_chunk_count,
+        },
     }
 
+    alerts = monitor_pipeline_health(result, config)
+    for alert in alerts:
+        level = alert.get("level", "INFO").upper()
+        message = alert.get("message", "")
+        recommendation = alert.get("recommendation")
+        if level == "ERROR":
+            logger.error("[HF Pipeline] %s", message)
+        elif level == "WARNING":
+            logger.warning("[HF Pipeline] %s", message)
+        else:
+            logger.info("[HF Pipeline] %s", message)
+        if recommendation:
+            logger.info("[HF Pipeline] Recommendation: %s", recommendation)
+
+    return result
+
+
+__all__ = ["_process_file_chunked_high_freq", "process_slice_with_multiple_bands_high_freq"]
 

--- a/src/core/high_freq_strategies.py
+++ b/src/core/high_freq_strategies.py
@@ -1,0 +1,563 @@
+"""High-frequency FRB detection strategies inspired by Yong-Kun Zhang.
+
+This module implements two complementary approaches tailored for the
+millimetre regime where dispersion sweeps collapse and traditional
+time--DM heuristics lose discriminative power:
+
+* Strategy 1 expands the DM search space and detects "bow-tie" patterns
+  on the time--DM plane with adaptive contrast metrics.
+* Strategy 2 performs a permissive zero-DM search followed by strict
+  DM-aware validation that enforces astrophysical consistency tests.
+
+Both strategies emit :class:`HighFreqCandidate` instances which are
+later deduplicated and ranked before being persisted by the pipeline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Sequence
+
+import logging
+import math
+
+import numpy as np
+
+from ..analysis.snr_utils import compute_snr_profile
+from ..config import config
+from ..detection.model_interface import classify_patch
+from ..preprocessing.dedispersion import d_dm_time_g, dedisperse_block, dedisperse_patch
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ExpandedDMRange:
+    """Descriptor for an expanded DM search space."""
+
+    min_dm: float
+    max_dm: float
+    step: float
+    n_trials: int
+    dm_values: np.ndarray
+
+    def clamp_index(self, idx: int) -> int:
+        return int(max(0, min(self.n_trials - 1, idx)))
+
+    def index_to_dm(self, idx: int) -> float:
+        idx = self.clamp_index(idx)
+        return float(self.dm_values[idx])
+
+    def dm_to_index(self, dm: float) -> int:
+        if self.n_trials <= 1 or self.max_dm <= self.min_dm:
+            return 0
+        ratio = (float(dm) - self.min_dm) / (self.max_dm - self.min_dm)
+        idx = int(round(ratio * (self.n_trials - 1)))
+        return self.clamp_index(idx)
+
+
+@dataclass
+class HighFreqCandidate:
+    """Container for candidates produced by the high-frequency pipeline."""
+
+    chunk_idx: int
+    slice_idx: int
+    band_idx: int
+    time_idx: int
+    dm_idx: int
+    dm: float
+    method: str
+    absolute_time: float
+    global_sample: int
+    snr: float
+    class_prob: float
+    confidence: float
+    width_samples: int | None = None
+    validation_results: dict[str, str] = field(default_factory=dict)
+    final_dm: float | None = None
+    initial_dm: float | None = None
+    contrast: float | None = None
+    candidate_box: tuple[int, int, int, int] | None = None
+    processed_patch: np.ndarray | None = None
+
+    def effective_dm(self) -> float:
+        return float(self.final_dm if self.final_dm is not None else self.dm)
+
+    def is_burst(self) -> bool:
+        return bool(self.class_prob >= float(config.CLASS_PROB))
+
+
+def calculate_expanded_dm_range(
+    traditional_max_dm: float,
+    multiplier: float,
+    step_coarse: float,
+    *,
+    min_dm: float = 0.0,
+    min_step: float = 1.0,
+) -> ExpandedDMRange:
+    """Return an expanded DM range compensating the suppressed dispersion."""
+
+    base_max = max(float(traditional_max_dm), 1.0)
+    multiplier = max(float(multiplier), 1.0)
+    max_dm = base_max * multiplier
+    step = max(float(step_coarse), float(min_step), 1.0)
+
+    n_trials = int(max(1, math.floor((max_dm - min_dm) / step) + 1))
+    adjusted_max = float(min_dm + step * (n_trials - 1))
+    dm_values = np.linspace(min_dm, adjusted_max, n_trials, dtype=np.float32)
+
+    logger.debug(
+        "Expanded DM range: min=%.2f max=%.2f step=%.2f trials=%d",
+        min_dm,
+        adjusted_max,
+        step,
+        n_trials,
+    )
+
+    return ExpandedDMRange(
+        min_dm=float(min_dm),
+        max_dm=adjusted_max,
+        step=float(step),
+        n_trials=n_trials,
+        dm_values=dm_values,
+    )
+
+
+def generate_time_dm_plane(block: np.ndarray, dm_range: ExpandedDMRange) -> np.ndarray:
+    """Generate the time--DM cube for the expanded DM range."""
+
+    height = int(dm_range.n_trials)
+    width = int(block.shape[0])
+    return d_dm_time_g(
+        block,
+        height=height,
+        width=width,
+        dm_min=dm_range.min_dm,
+        dm_max=dm_range.max_dm,
+    )
+
+
+def _compute_bow_tie_contrast(
+    dm_profile: np.ndarray,
+    peak_idx: int,
+    wing_width: int,
+) -> float:
+    left_lo = max(0, peak_idx - wing_width)
+    left_hi = max(left_lo, peak_idx)
+    right_lo = min(dm_profile.size, peak_idx + 1)
+    right_hi = min(dm_profile.size, peak_idx + wing_width + 1)
+
+    wings: List[float] = []
+    if left_hi > left_lo:
+        wings.append(float(np.mean(np.abs(dm_profile[left_lo:left_hi]))))
+    if right_hi > right_lo:
+        wings.append(float(np.mean(np.abs(dm_profile[right_lo:right_hi]))))
+    wing_level = float(np.mean(wings)) if wings else 0.0
+    if wing_level <= 0.0:
+        return 0.0
+    return float(dm_profile[peak_idx]) / wing_level
+
+
+def run_bow_tie_strategy(
+    band_img: np.ndarray,
+    dm_range: ExpandedDMRange,
+    *,
+    block: np.ndarray,
+    freq_down: np.ndarray,
+    start_idx: int,
+    absolute_start_time: float,
+    cls_model,
+    chunk_idx: int,
+    slice_idx: int,
+    band_idx: int,
+    dt_ds: float,
+) -> list[HighFreqCandidate]:
+    """Detect bow-tie candidates on a DM-expanded time--DM plane."""
+
+    if band_img is None or band_img.size == 0:
+        return []
+
+    wing_width = int(getattr(config, "HF_BOW_TIE_WING_WIDTH", 20))
+    min_idx = int(getattr(config, "HF_BOW_TIE_MIN_DM_INDEX", 10))
+    min_snr = float(getattr(config, "HF_BOW_TIE_MIN_SNR", 5.0))
+    threshold = float(getattr(config, "HF_BOW_TIE_THRESHOLD", 2.0))
+
+    height, width = band_img.shape
+    scale_x = 512.0 / max(1, width)
+    scale_y = 512.0 / max(1, height)
+    half_w = max(4, width // 64)
+    half_h = max(3, height // 32)
+
+    candidates: list[HighFreqCandidate] = []
+
+    for t_idx in range(width):
+        dm_profile = band_img[:, t_idx]
+        if dm_profile.size == 0:
+            continue
+        peak_idx = int(np.argmax(dm_profile))
+        if peak_idx < min_idx:
+            continue
+        contrast = _compute_bow_tie_contrast(dm_profile, peak_idx, wing_width)
+        if contrast < threshold:
+            continue
+
+        dm_val = dm_range.index_to_dm(peak_idx)
+        global_sample = int(start_idx + t_idx)
+
+        patch, _ = dedisperse_patch(block, freq_down, dm_val, global_sample)
+        snr_profile, _, width_vec = compute_snr_profile(patch)
+        if snr_profile.size == 0:
+            continue
+        peak_pos = int(np.argmax(snr_profile))
+        snr_val = float(snr_profile[peak_pos])
+        if snr_val < min_snr:
+            continue
+
+        width_samples = int(width_vec[peak_pos]) if width_vec.size > peak_pos else None
+        class_prob, proc_patch = classify_patch(cls_model, patch)
+
+        conf = min(0.99, max(0.05, contrast / max(threshold, 1e-3)))
+        x1 = int(round(max(0, t_idx - half_w) * scale_x))
+        x2 = int(round(min(width - 1, t_idx + half_w) * scale_x))
+        y1 = int(round(max(0, peak_idx - half_h) * scale_y))
+        y2 = int(round(min(height - 1, peak_idx + half_h) * scale_y))
+        candidate = HighFreqCandidate(
+            chunk_idx=chunk_idx,
+            slice_idx=slice_idx,
+            band_idx=band_idx,
+            time_idx=t_idx,
+            dm_idx=peak_idx,
+            dm=float(dm_val),
+            method="bow_tie_expanded",
+            absolute_time=float(absolute_start_time + t_idx * dt_ds),
+            global_sample=global_sample,
+            snr=snr_val,
+            class_prob=float(class_prob),
+            confidence=float(conf),
+            width_samples=width_samples,
+            final_dm=float(dm_val),
+            initial_dm=float(dm_val),
+            contrast=float(contrast),
+            candidate_box=(x1, y1, x2, y2),
+            processed_patch=proc_patch,
+        )
+        candidates.append(candidate)
+
+    return candidates
+
+
+def zero_dm_classifier(
+    block: np.ndarray,
+    freq_down: np.ndarray,
+    start_idx: int,
+    end_idx: int,
+    *,
+    cls_model,
+    absolute_start_time: float,
+    chunk_idx: int,
+    slice_idx: int,
+    dt_ds: float,
+    dm_range: ExpandedDMRange,
+) -> list[HighFreqCandidate]:
+    """Permissive zero-DM classification stage."""
+
+    trials: Sequence[float] = getattr(config, "HF_ZERO_DM_TRIALS", [0.0, 1.0, 2.0, 5.0])
+    sensitivity = float(getattr(config, "HF_ZERO_DM_SENSITIVITY", 0.4))
+    min_snr = float(getattr(config, "HF_ZERO_DM_MIN_SNR", 3.0))
+    max_candidates = int(getattr(config, "HF_ZERO_DM_MAX_CANDIDATES", 1000))
+
+    width = max(0, int(end_idx - start_idx))
+    scale_x = 512.0 / max(1, width)
+    half_w = max(4, width // 64)
+    height = dm_range.n_trials
+    scale_y = 512.0 / max(1, height)
+    half_h = max(3, height // 32)
+
+    provisional: list[HighFreqCandidate] = []
+
+    for dm_trial in trials:
+        dedisp_block = dedisperse_block(block, freq_down, float(dm_trial), start_idx, width)
+        if dedisp_block is None or dedisp_block.size == 0:
+            continue
+        snr_profile, _, width_vec = compute_snr_profile(dedisp_block)
+        if snr_profile.size == 0:
+            continue
+
+        order = np.argsort(snr_profile)[::-1]
+        for idx in order:
+            snr_val = float(snr_profile[idx])
+            if snr_val < min_snr:
+                break
+            global_sample = int(start_idx + idx)
+            patch, _ = dedisperse_patch(block, freq_down, float(dm_trial), global_sample)
+            class_prob, proc_patch = classify_patch(cls_model, patch)
+            if class_prob < sensitivity:
+                continue
+            width_samples = int(width_vec[idx]) if width_vec.size > idx else None
+            dm_idx = dm_range.dm_to_index(dm_trial)
+            y1 = int(round(max(0, dm_idx - half_h) * scale_y))
+            y2 = int(round(min(height - 1, dm_idx + half_h) * scale_y))
+            x1 = int(round(max(0, idx - half_w) * scale_x))
+            x2 = int(round(min(width - 1, idx + half_w) * scale_x))
+            candidate = HighFreqCandidate(
+                chunk_idx=chunk_idx,
+                slice_idx=slice_idx,
+                band_idx=0,
+                time_idx=int(idx),
+                dm_idx=dm_idx,
+                dm=float(dm_trial),
+                method="zero_dm_seed",
+                absolute_time=float(absolute_start_time + idx * dt_ds),
+                global_sample=global_sample,
+                snr=snr_val,
+                class_prob=float(class_prob),
+                confidence=float(class_prob),
+                width_samples=width_samples,
+                initial_dm=float(dm_trial),
+                candidate_box=(x1, y1, x2, y2),
+                processed_patch=proc_patch,
+            )
+            provisional.append(candidate)
+
+    provisional.sort(key=lambda c: (c.class_prob, c.snr), reverse=True)
+    if len(provisional) > max_candidates:
+        provisional = provisional[:max_candidates]
+    return provisional
+
+
+def _iter_dm_grid(dm_min: float, dm_max: float, step: float) -> Iterable[float]:
+    if step <= 0:
+        step = 1.0
+    dm = float(dm_min)
+    while dm <= dm_max + 1e-6:
+        yield dm
+        dm += step
+
+
+def find_best_dm(
+    candidate: HighFreqCandidate,
+    block: np.ndarray,
+    freq_down: np.ndarray,
+    dt_ds: float,
+) -> tuple[float, float, int | None]:
+    """Return the DM that maximises S/N for the candidate."""
+
+    dm_min = float(getattr(config, "HF_VALIDATION_DM_MIN", 0.0))
+    dm_max = float(getattr(config, "HF_VALIDATION_DM_MAX", config.DM_max))
+    dm_step = float(getattr(config, "HF_VALIDATION_DM_STEP", 5.0))
+    patch_len = int(getattr(config, "HF_VALIDATION_PATCH_LEN", 256))
+
+    best_dm = float(candidate.dm)
+    best_snr = float(candidate.snr)
+    best_width: int | None = candidate.width_samples
+
+    for dm_val in _iter_dm_grid(dm_min, dm_max, dm_step):
+        patch, _ = dedisperse_patch(block, freq_down, dm_val, candidate.global_sample, patch_len)
+        if patch is None or patch.size == 0:
+            continue
+        snr_profile, _, width_vec = compute_snr_profile(patch)
+        if snr_profile.size == 0:
+            continue
+        idx = int(np.argmax(snr_profile))
+        snr_val = float(snr_profile[idx])
+        if snr_val > best_snr:
+            best_snr = snr_val
+            best_dm = float(dm_val)
+            best_width = int(width_vec[idx]) if width_vec.size > idx else best_width
+
+    return best_dm, best_snr, best_width
+
+
+def _split_frequency_subbands(
+    block: np.ndarray,
+    freq_down: np.ndarray,
+    n_subbands: int,
+) -> list[tuple[np.ndarray, np.ndarray]]:
+    n_subbands = max(1, min(int(n_subbands), freq_down.size))
+    subbands: list[tuple[np.ndarray, np.ndarray]] = []
+    for sub_idx in range(n_subbands):
+        start = int(np.floor(sub_idx * freq_down.size / n_subbands))
+        end = int(np.floor((sub_idx + 1) * freq_down.size / n_subbands))
+        if end <= start:
+            continue
+        subbands.append((block[:, start:end], freq_down[start:end]))
+    return subbands
+
+
+def validate_subband_consistency(
+    candidate: HighFreqCandidate,
+    block: np.ndarray,
+    freq_down: np.ndarray,
+) -> bool:
+    n_subbands = int(getattr(config, "HF_SUBBAND_COUNT", 4))
+    threshold = float(getattr(config, "HF_SUBBAND_SNR_THRESHOLD", 5.0))
+    min_ratio = float(getattr(config, "HF_SUBBAND_CONSISTENCY_THRESHOLD", 0.75))
+
+    subbands = _split_frequency_subbands(block, freq_down, n_subbands)
+    detections = 0
+    for sub_block, sub_freq in subbands:
+        patch, _ = dedisperse_patch(sub_block, sub_freq, candidate.effective_dm(), candidate.global_sample)
+        if patch is None or patch.size == 0:
+            continue
+        snr_profile, _, _ = compute_snr_profile(patch)
+        if snr_profile.size == 0:
+            continue
+        snr_val = float(np.max(snr_profile))
+        if snr_val >= threshold:
+            detections += 1
+    if not subbands:
+        return False
+    ratio = detections / len(subbands)
+    return ratio >= min_ratio
+
+
+def validate_temporal_consistency(
+    candidate: HighFreqCandidate,
+    block: np.ndarray,
+    freq_down: np.ndarray,
+    dt_ds: float,
+) -> bool:
+    window_sec = float(getattr(config, "HF_TEMPORAL_CHUNK_SEC", 30.0))
+    window_samples = max(1, int(window_sec / dt_ds))
+    start = max(0, candidate.global_sample - window_samples // 2)
+    end = min(block.shape[0], start + window_samples)
+    if end <= start:
+        return False
+    dedisp_block = dedisperse_block(block, freq_down, candidate.effective_dm(), start, end - start)
+    if dedisp_block is None or dedisp_block.size == 0:
+        return False
+    snr_profile, _, _ = compute_snr_profile(dedisp_block)
+    if snr_profile.size == 0:
+        return False
+    rel_idx = candidate.global_sample - start
+    if rel_idx < 0 or rel_idx >= snr_profile.size:
+        return False
+    snr_val = float(snr_profile[rel_idx])
+    threshold = float(getattr(config, "HF_TEMPORAL_SNR_THRESHOLD", 5.0))
+    return snr_val >= threshold
+
+
+def dm_aware_validation(
+    candidates: Sequence[HighFreqCandidate],
+    block: np.ndarray,
+    freq_down: np.ndarray,
+    dt_ds: float,
+    dm_range: ExpandedDMRange,
+) -> list[HighFreqCandidate]:
+    """Apply DM-aware validation to permissive zero-DM candidates."""
+
+    validated: list[HighFreqCandidate] = []
+    min_significant_dm = float(getattr(config, "HF_MIN_SIGNIFICANT_DM", 15.0))
+
+    for candidate in candidates:
+        best_dm, best_snr, best_width = find_best_dm(candidate, block, freq_down, dt_ds)
+        candidate.final_dm = best_dm
+        candidate.snr = best_snr
+        candidate.width_samples = best_width
+        candidate.dm_idx = dm_range.dm_to_index(best_dm)
+        candidate.method = "zero_dm_validated"
+
+        validation = {}
+        if best_dm <= min_significant_dm:
+            validation["dm_test"] = "FAILED"
+            candidate.validation_results = validation
+            continue
+        validation["dm_test"] = "PASSED"
+
+        if validate_subband_consistency(candidate, block, freq_down):
+            validation["subband_test"] = "PASSED"
+        else:
+            validation["subband_test"] = "FAILED"
+
+        if validation["subband_test"] == "FAILED":
+            candidate.validation_results = validation
+            continue
+
+        if validate_temporal_consistency(candidate, block, freq_down, dt_ds):
+            validation["temporal_test"] = "PASSED"
+        else:
+            validation["temporal_test"] = "FAILED"
+
+        candidate.validation_results = validation
+        if all(val == "PASSED" for val in validation.values()):
+            candidate.dm = best_dm
+            candidate.confidence = max(candidate.confidence, candidate.class_prob)
+            validated.append(candidate)
+
+    return validated
+
+
+def deduplicate_and_rank_candidates(
+    candidates: Sequence[HighFreqCandidate],
+) -> list[HighFreqCandidate]:
+    if not candidates:
+        return []
+    time_tol = float(getattr(config, "HF_DEDUP_TIME_TOL_SEC", 1.0))
+    dm_tol = float(getattr(config, "HF_DEDUP_DM_TOL", 50.0))
+
+    groups: list[list[HighFreqCandidate]] = []
+    for cand in candidates:
+        placed = False
+        for group in groups:
+            ref = group[0]
+            if abs(cand.absolute_time - ref.absolute_time) <= time_tol and abs(cand.effective_dm() - ref.effective_dm()) <= dm_tol:
+                group.append(cand)
+                placed = True
+                break
+        if not placed:
+            groups.append([cand])
+
+    ranked: list[HighFreqCandidate] = []
+    for group in groups:
+        def score(entry: HighFreqCandidate) -> tuple:
+            passed = sum(1 for v in entry.validation_results.values() if v == "PASSED")
+            return (entry.snr, passed, entry.class_prob, entry.confidence)
+
+        best = max(group, key=score)
+        ranked.append(best)
+
+    ranked.sort(key=lambda c: (c.snr, c.class_prob, c.confidence), reverse=True)
+    return ranked
+
+
+def monitor_pipeline_health(processing_results: dict, config_module) -> list[dict]:
+    """Evaluate monitoring metrics for the integrated high-frequency pipeline."""
+
+    alerts: list[dict] = []
+    stats = processing_results.get("processing_stats", {})
+
+    strat1 = float(stats.get("strategy_1_count", 0))
+    strat2_initial = float(stats.get("strategy_2_initial_count", 0))
+    strat2_valid = float(stats.get("strategy_2_validated_count", 0))
+    total_time = float(stats.get("total_processing_time", 0.0))
+    max_time = float(getattr(config_module, "MAX_PROCESSING_TIME_SEC", getattr(config_module, "max_processing_time_sec", 0)))
+
+    ratio_threshold = float(getattr(config_module, "HF_MONITOR_BOW_TIE_RATIO", 0.1))
+    if strat2_initial > 0:
+        bow_tie_ratio = strat1 / max(strat2_initial, 1.0)
+        if bow_tie_ratio < ratio_threshold:
+            alerts.append({
+                "level": "WARNING",
+                "message": "Bow-tie recovery rate below expected threshold",
+                "recommendation": "Increase HF_DM_EXPANSION_FACTOR or adjust contrast threshold",
+            })
+
+    if strat2_initial > 0:
+        false_positive_rate = 1.0 - (strat2_valid / strat2_initial)
+        if false_positive_rate > 0.9:
+            alerts.append({
+                "level": "ERROR",
+                "message": f"Zero-DM false positive rate {false_positive_rate:.0%} exceeds limit",
+                "recommendation": "Tighten HF_ZERO_DM_SENSITIVITY or validation thresholds",
+            })
+
+    if max_time and total_time > max_time:
+        alerts.append({
+            "level": "WARNING",
+            "message": f"Processing time {total_time:.1f}s exceeds configured maximum",
+            "recommendation": "Reduce DM sampling resolution or optimise dedispersion",
+        })
+
+    return alerts
+


### PR DESCRIPTION
## Summary
- add explicit configuration knobs for Zhang high-frequency search strategies
- implement DM range expansion, bow-tie detection, zero-DM validation, and monitoring helpers
- refactor the high-frequency pipeline to use the new strategies, emit plots, persist candidates, and report health metrics

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68ca19549aa48322b111ca0886a31039